### PR TITLE
feat: WP-151 adoptions (HTML renderer, safety primitives, adversarial QA) — framework 5.11.0

### DIFF
--- a/.claude/agents/do.md
+++ b/.claude/agents/do.md
@@ -9,6 +9,7 @@ iteration:
   completionPromises:
     - "<promise>COMPLETE</promise>"
     - "<promise>BLOCKED</promise>"
+    - "<promise>CONFUSED</promise>"
   validationRules:
     - config_valid
     - secrets_safe

--- a/.claude/agents/me.md
+++ b/.claude/agents/me.md
@@ -9,6 +9,7 @@ iteration:
   completionPromises:
     - "<promise>COMPLETE</promise>"
     - "<promise>BLOCKED</promise>"
+    - "<promise>CONFUSED</promise>"
   validationRules:
     - tests_pass
     - tests_written
@@ -68,6 +69,7 @@ Software engineer who writes clean, maintainable code. Orchestrates domain skill
 - Refactor unrelated code in same change
 - Mark implementation as final without routing to @agent-qa
 - Forward-patch around a broken assumption — if the planned approach, architecture, or constraint from @agent-ta proves wrong or infeasible, STOP and emit `<promise>BLOCKED</promise>`, surface the invalidated assumption explicitly, and route back to @agent-ta to re-plan rather than improvising a workaround that diverges from the task graph
+- Guess when hitting a genuine mid-task decision fork that only the user can resolve — emit `<promise>CONFUSED</promise>` with a QUESTION / OPTIONS / CONTEXT block (see CLAUDE.md Confused Loop-State), suspend iteration, and wait for the user's answer before continuing. CONFUSED is for user-judgment forks; BLOCKED is for external blockers.
 
 ## Design Methodology (Kent Beck's 4 Rules of Simple Design)
 

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -9,6 +9,7 @@ iteration:
   completionPromises:
     - "<promise>COMPLETE</promise>"
     - "<promise>BLOCKED</promise>"
+    - "<promise>CONFUSED</promise>"
   validationRules:
     - tests_written
     - tests_pass
@@ -145,21 +146,44 @@ Where `<type>` is one of:
 - `test-run` — a failable test command, its exit code, and an output excerpt
 - `file-check` — a file that exists in the expected shape (path + key property verified)
 - `diff-check` — a diff or comparison result against a spec or expected value
+- `adversarial-run` — optional cross-model adversarial pass (see below)
 
 **Examples:**
 ```
 ARTIFACT: test-run|pytest tests/test_auth.py exit=0 "5 passed, 0 failed"
 ARTIFACT: file-check|.claude/agents/manifest.json exists agents=16
 ARTIFACT: diff-check|expected 16 agents actual 16 agents match
+ARTIFACT: adversarial-run|llm FINDINGS: none found exit=0
 ```
 
 The artifact must bind the verdict to an EXTERNAL, independently verifiable result —
 not a claim about what the model observed during code review.
 
+**Optional: Adversarial pass (availability-gated)**
+
+When a second-model CLI is configured, you may run the adversarial pass as a bonus
+verification step and include its output in your verdict:
+
+```bash
+# Run at the end of your QA workflow — produces ARTIFACT line or nothing
+adversarial_artifact="$(.claude/hooks/bin/adversarial-pass.sh)"
+```
+
+If `$adversarial_artifact` is non-empty, include it in your final message alongside
+or instead of a `test-run` artifact. If empty (no CLI available), proceed normally —
+the gate still passes on `test-run` alone.
+
+Configure the second model:
+```bash
+export COPILOT_ADVERSARIAL_CMD="llm"    # or: mods, codex, /path/to/wrapper.sh
+export COPILOT_ADVERSARIAL=off          # disable entirely
+```
+
 **Complete example closing lines:**
 ```
 Task: TASK-5 | WP: WP-22
 ARTIFACT: test-run|pytest tests/test_auth.py::test_login exit=0 "3 passed"
+ARTIFACT: adversarial-run|llm FINDINGS: none found exit=0
 VERDICT: APPROVED
 ```
 

--- a/.claude/agents/sec.md
+++ b/.claude/agents/sec.md
@@ -9,6 +9,7 @@ iteration:
   completionPromises:
     - "<promise>COMPLETE</promise>"
     - "<promise>BLOCKED</promise>"
+    - "<promise>CONFUSED</promise>"
   validationRules:
     - vulnerabilities_assessed
     - critical_issues_flagged

--- a/.claude/agents/ta.md
+++ b/.claude/agents/ta.md
@@ -9,6 +9,7 @@ iteration:
   completionPromises:
     - "<promise>COMPLETE</promise>"
     - "<promise>BLOCKED</promise>"
+    - "<promise>CONFUSED</promise>"
   validationRules:
     - prd_created
     - tasks_created

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -8,6 +8,8 @@ The hooks system provides lifecycle-based injection and enforcement for the main
 |-----------|----------------------|------|-------------|
 | `pretool-check.sh` | PreToolUse | Force-delegate (5 consecutive same-tool calls) | Mandatory — exit 2 |
 | `pretool-check.sh` | PreToolUse | QA gate (after @agent-me, before @agent-qa) | Mandatory — exit 2 |
+| `pretool-check.sh` | PreToolUse | Destructive-command safety `/careful` | block → exit 2; warn → exit 0 + stderr |
+| `pretool-check.sh` | PreToolUse | Path-scope lock `/freeze` | Mandatory — exit 2 |
 | `subagent-stop.sh` | SubagentStop | QA gate state manager | Mandatory state write |
 | `user-prompt-submit.sh` | UserPromptSubmit | Session length cap (500 / 750 turns) | Advisory — systemMessage |
 | `session-start.json` | SessionStart | Protocol injection | Advisory |
@@ -19,6 +21,9 @@ The hooks system provides lifecycle-based injection and enforcement for the main
 | `COPILOT_FORCE_DELEGATE=off` | Force-delegate rule |
 | `COPILOT_QA_GATE=off` | QA gate rule + state management |
 | `COPILOT_SESSION_CAP=off` | Session length advisories |
+| `COPILOT_CAREFUL=off` | Destructive-command safety rule (`/careful`) |
+| `COPILOT_FREEZE=off` | Path-scope lock rule (`/freeze`) |
+| `COPILOT_SAFETY=off` | Both `/careful` and `/freeze` (convenience alias) |
 
 ### State Directory
 
@@ -255,7 +260,9 @@ Manages QA-gate state in response to `@agent-me` and `@agent-qa` subagent comple
 
 | Event | Action |
 |-------|--------|
-| `agent_type == "me"` | Extract `TASK-N` from final message, add to `pending_tasks` |
+| `agent_type == "me"` with `<promise>BLOCKED</promise>` | Skip gate — blocker surfaces to user, no `pending_tasks` entry |
+| `agent_type == "me"` with `<promise>CONFUSED</promise>` | Skip gate — decision fork surfaces to user, no `pending_tasks` entry |
+| `agent_type == "me"` (normal completion) | Extract `TASK-N` from final message, add to `pending_tasks` |
 | `agent_type == "qa"` with pass verdict | Remove task from `pending_tasks`, clear retry counter |
 | `agent_type == "qa"` with fail verdict | Increment retry counter; after 3 failures, auto-unblock + advisory |
 | Any other agent type | No action |
@@ -285,12 +292,14 @@ Where `<type>` is one of:
 - `test-run` — a failable test command with exit code and output excerpt
 - `file-check` — a file that exists in the expected shape
 - `diff-check` — a diff or comparison result against a spec
+- `adversarial-run` — cross-model adversarial pass (optional/bonus; see below)
 
 **Examples:**
 ```
 ARTIFACT: test-run|pytest tests/test_auth.py exit=0 "5 passed, 0 failed"
 ARTIFACT: file-check|.claude/agents/manifest.json exists agents=16
 ARTIFACT: diff-check|expected 16 agents actual 16 agents match
+ARTIFACT: adversarial-run|llm FINDINGS: none found exit=0
 ```
 
 The escape hatches (`COPILOT_QA_GATE=off`) still bypass the gate entirely — including the
@@ -317,10 +326,48 @@ After 3 consecutive QA failures, the hook emits:
 { "systemMessage": "QA gate degraded to advisory: TASK-N failed QA 3 consecutive times. Main session is unblocked, but human review is strongly recommended..." }
 ```
 
+### Adversarial Pass (Optional, Availability-Gated)
+
+An optional second-model "try to break this diff" pass that @agent-qa can run via:
+
+```bash
+artifact="$(.claude/hooks/bin/adversarial-pass.sh)"
+# Include $artifact in the verdict if non-empty (it's a bonus, never required)
+```
+
+**Detection order:**
+1. `COPILOT_ADVERSARIAL_CMD` env var — explicit command (may include flags/path)
+2. PATH probe: `codex`, `llm`, `mods` (first found)
+3. Nothing found → clean no-op (exit 0, no output, gate unaffected)
+
+**Configuration:**
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `COPILOT_ADVERSARIAL_CMD` | Explicit CLI command to use | (none — uses PATH probe) |
+| `COPILOT_ADVERSARIAL_TIMEOUT` | Timeout in seconds | `30` |
+| `COPILOT_ADVERSARIAL=off` | Disable entirely | (enabled when absent) |
+
+**Example configuration:**
+```bash
+export COPILOT_ADVERSARIAL_CMD="llm"           # use Simon Willison's llm tool
+export COPILOT_ADVERSARIAL_CMD="mods --no-cache" # use charm's mods tool
+export COPILOT_ADVERSARIAL_CMD="/path/to/wrapper.sh"  # custom wrapper
+```
+
+**Invocation convention:** Prompt + diff are piped to the command via stdin. For CLIs requiring a separate argument, set `COPILOT_ADVERSARIAL_CMD` to a wrapper script.
+
+**Degradation:** Any error (CLI not found, non-zero exit, timeout, empty diff) degrades cleanly to no-op. The gate is NEVER blocked by a missing or failing adversarial CLI.
+
+**Artifact type:** `adversarial-run` — recognized by `subagent-stop.sh` alongside `test-run`, `file-check`, `diff-check`. It satisfies the artifact requirement on its own but is never a new mandatory requirement. The gate still passes on `test-run` alone.
+
+**Test:** `.claude/hooks/bin/test-adversarial-pass.sh`
+
 ### Escape Hatch
 
 ```bash
-export COPILOT_QA_GATE=off  # Disables all QA gate state management
+export COPILOT_QA_GATE=off       # Disables all QA gate state management
+export COPILOT_ADVERSARIAL=off   # Disables adversarial pass only
 ```
 
 ---
@@ -357,15 +404,70 @@ Security validation is handled inside `pretool-check.sh` as part of the PreToolU
 
 ### Currently Active Rules
 
-`pretool-check.sh` currently enforces two rules only:
-
 | Rule | Trigger | Action |
 |------|---------|--------|
 | `rule_force_delegate` | 5+ consecutive Bash/Read/Edit calls | Deny, suggest agent delegation |
 | `rule_qa_gate` | Task in pending-qa state for this session | Deny all except Agent(qa) and safe tc reads |
+| `rule_destructive_command` | Bash command matching a pattern in `security-rules.json` | `action: block` → deny (exit 2); `action: warn` → stderr warning (exit 0) |
+| `rule_path_scope` | Edit/Write/Bash targeting a path outside the freeze dir | Deny (exit 2) |
 
-`security-rules.json` is present in this directory but is **not yet wired into `pretool-check.sh`**. Secret detection, destructive-command blocking, and sensitive-file protection described in that file are aspirational — they are not currently enforced at runtime.
+### `/careful` — Destructive Command Safety (rule_destructive_command)
 
-### Adding Security Rules (Future)
+Reads `security-rules.json` on every Bash tool call and tests the command string against all enabled rules' patterns (case-insensitive, via jq `test()`).
+
+- Rules with `"action": "block"` cause a deny (exit 2 + JSON reason). Example: `git push --force`.
+- Rules with `"action": "warn"` emit a `[safety-warn]` message to stderr and allow (exit 0). Example: `git reset --hard`, `rm -rf /`.
+
+**Adding a new pattern:** Edit `security-rules.json`. Add a pattern to an existing rule's `patterns` array, or add a new rule object following the same schema. The hook reads the file at runtime — no hook restart needed.
+
+**Bypass:**
+```bash
+export COPILOT_CAREFUL=off   # disables /careful for this shell session
+export COPILOT_SAFETY=off    # disables both /careful and /freeze
+```
+
+**Test:**
+```bash
+.claude/hooks/bin/test-safety-rules.sh
+```
+
+### `/freeze` — Path-Scope Lock (rule_path_scope)
+
+Restricts Edit, Write, and Bash file-redirect operations to a declared directory. Prevents accidental out-of-scope edits when working on a focused sub-tree.
+
+**Enable:**
+```bash
+.claude/hooks/bin/freeze.sh on /path/to/your/project
+# or manually:
+echo /path/to/your/project > .claude/hooks/state/.freeze
+```
+
+**Disable:**
+```bash
+.claude/hooks/bin/freeze.sh off
+# or manually:
+rm .claude/hooks/state/.freeze
+```
+
+**Check status:**
+```bash
+.claude/hooks/bin/freeze.sh status
+```
+
+**Bypass:**
+```bash
+export COPILOT_FREEZE=off    # disables /freeze for this shell session
+export COPILOT_SAFETY=off    # disables both /careful and /freeze
+```
+
+**State file:** `.claude/hooks/state/.freeze` (gitignored, ephemeral — one absolute path per line)
+
+**Scope per tool:**
+- `Edit` / `Write`: hard block if `file_path` is not under the freeze dir (exact, reliable)
+- `Bash`: best-effort — checks redirect targets (`> path` / `>> path`) for paths outside freeze dir; does not parse arbitrary command arguments
+
+### Adding Security Rules
 
 To wire in a new security check, add a `rule_<name>()` function to `pretool-check.sh` and call it in the dispatch section near the bottom of the file. Rules return 0 (allow) or call `deny "<reason>"` (which writes JSON and exits 2).
+
+To add a new destructive-command pattern that fires through `rule_destructive_command`, add it to `security-rules.json` following the existing schema — no code change needed.

--- a/.claude/hooks/bin/adversarial-pass.sh
+++ b/.claude/hooks/bin/adversarial-pass.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# adversarial-pass.sh — Availability-gated cross-model adversarial QA pass
+#
+# PURPOSE:
+#   When a second-model CLI is available (via env config or PATH probe), runs an
+#   adversarial "try to break this diff" pass and emits an ARTIFACT line to stdout.
+#
+#   When no CLI is found → clean NO-OP, exit 0, emits nothing, never blocks the gate.
+#   When CLI errors, times out, or diff is empty → same clean NO-OP.
+#
+# DETECTION (in priority order):
+#   1. COPILOT_ADVERSARIAL_CMD env var — explicit command (may include flags/path)
+#   2. PATH probe: codex, llm, mods (first found wins)
+#   3. Nothing found → no-op
+#
+# OUTPUT (when a CLI is found and succeeds):
+#   Printed to stdout — include this line verbatim in your QA verdict:
+#     ARTIFACT: adversarial-run|<cmd> <findings-excerpt> exit=<code>
+#
+#   When no CLI is found or any error occurs: no output, exit 0.
+#
+# CONFIGURATION:
+#   COPILOT_ADVERSARIAL_CMD      — explicit CLI to use (overrides PATH probe)
+#   COPILOT_ADVERSARIAL_TIMEOUT  — timeout in seconds (default: 30)
+#   COPILOT_ADVERSARIAL=off      — disable entirely (clean no-op regardless)
+#
+# INVOCATION CONVENTION:
+#   The adversarial prompt and diff are combined and piped to the configured
+#   command via stdin.  For CLIs that require a separate argument (e.g. a
+#   system prompt flag), set COPILOT_ADVERSARIAL_CMD to a wrapper script.
+#
+# USAGE (by @agent-qa):
+#   artifact="$(.claude/hooks/bin/adversarial-pass.sh)"
+#   # If non-empty, include $artifact in the final verdict message.
+#   # It is a bonus: gate still passes on test-run alone.
+#
+#   # Or pipe an explicit diff:
+#   artifact="$(git diff HEAD~1 | .claude/hooks/bin/adversarial-pass.sh)"
+#
+# ARTIFACT TYPE:
+#   adversarial-run — optional / bonus; recognized by subagent-stop.sh parser
+#   alongside test-run, file-check, diff-check. It NEVER becomes a gate blocker:
+#   the QA gate still unblocks on any single recognized artifact type.
+#
+# ESCAPE HATCH:
+#   export COPILOT_ADVERSARIAL=off   — disable for this shell session
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Escape hatch
+# ---------------------------------------------------------------------------
+if [[ "${COPILOT_ADVERSARIAL:-}" == "off" ]]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+readonly TIMEOUT="${COPILOT_ADVERSARIAL_TIMEOUT:-30}"
+readonly PROBE_ALLOWLIST=("codex" "llm" "mods")
+readonly ADVERSARIAL_PROMPT="You are an adversarial code reviewer. A code diff is piped below. Find specific bugs, security flaws, edge-case failures, or correctness issues introduced by this change. Be concise. Start your reply with FINDINGS: followed by a single-line summary (or: FINDINGS: none found)."
+
+# ---------------------------------------------------------------------------
+# CLI detection
+# Returns the command string on stdout; exits 1 if nothing found.
+# ---------------------------------------------------------------------------
+detect_cmd() {
+  # 1. Explicit env var takes priority
+  if [[ -n "${COPILOT_ADVERSARIAL_CMD:-}" ]]; then
+    local base_cmd
+    base_cmd="$(printf '%s' "$COPILOT_ADVERSARIAL_CMD" | awk '{print $1}')"
+    if command -v "$base_cmd" >/dev/null 2>&1; then
+      printf '%s' "$COPILOT_ADVERSARIAL_CMD"
+      return 0
+    fi
+    # Configured but base command not found on PATH → no-op (silent)
+    return 1
+  fi
+
+  # 2. Probe allowlist — first found wins
+  for candidate in "${PROBE_ALLOWLIST[@]}"; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+
+  # 3. Nothing found
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  # Detect CLI — if none found, clean no-op
+  local cmd=""
+  if ! cmd="$(detect_cmd 2>/dev/null)" || [[ -z "$cmd" ]]; then
+    exit 0
+  fi
+
+  # Read diff: from stdin if piped, otherwise from git diff
+  local diff_input=""
+  if [[ ! -t 0 ]]; then
+    diff_input="$(cat)"
+  else
+    diff_input="$(git diff 2>/dev/null || true)"
+  fi
+
+  # Empty diff → nothing to review, no-op
+  if [[ -z "$(printf '%s' "$diff_input" | tr -d '[:space:]')" ]]; then
+    exit 0
+  fi
+
+  # Combine prompt + diff for stdin-based invocation
+  local combined_input
+  combined_input="$(printf '%s\n\nDIFF:\n%s\n' "$ADVERSARIAL_PROMPT" "$diff_input")"
+
+  # Temp file for capturing output
+  local tmpout
+  tmpout="$(mktemp 2>/dev/null)" || exit 0
+
+  # Run with timeout (macOS-compatible: background process + watchdog subshell)
+  printf '%s' "$combined_input" | eval "$cmd" > "$tmpout" 2>&1 &
+  local bg_pid=$!
+
+  # Watchdog: kill background process after timeout
+  (
+    sleep "$TIMEOUT" 2>/dev/null
+    kill "$bg_pid" 2>/dev/null || true
+  ) &
+  local watchdog_pid=$!
+
+  # Wait for the model to finish
+  wait "$bg_pid" 2>/dev/null
+  local exit_code=$?
+
+  # Clean up watchdog
+  kill "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+
+  # Read output
+  local raw_output=""
+  raw_output="$(cat "$tmpout" 2>/dev/null || true)"
+  rm -f "$tmpout"
+
+  # Degrade to no-op on non-zero exit (includes timeout: SIGTERM=143, SIGKILL=137)
+  if [[ $exit_code -ne 0 ]]; then
+    exit 0
+  fi
+
+  # Extract findings: prefer FINDINGS: line, else first non-empty line
+  local findings=""
+  findings="$(printf '%s' "$raw_output" | grep -m1 -iE '^[[:space:]]*FINDINGS:' | head -c 200 || true)"
+  if [[ -z "$findings" ]]; then
+    findings="$(printf '%s' "$raw_output" | grep -m1 '[^[:space:]]' | head -c 120 || true)"
+  fi
+  if [[ -z "$findings" ]]; then
+    findings="no output"
+  fi
+
+  # Sanitize: collapse to single line, remove pipe chars (ARTIFACT delimiter)
+  local findings_clean
+  findings_clean="$(printf '%s' "$findings" \
+    | tr '\n\r\t' '   ' \
+    | tr -s ' ' \
+    | sed 's/[|]/-/g' \
+    | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+
+  # Command name for artifact label (base name only)
+  local cmd_name
+  cmd_name="$(printf '%s' "$cmd" | awk '{print $1}' | xargs basename 2>/dev/null \
+    || printf '%s' "$cmd" | awk '{print $1}')"
+
+  # Emit ARTIFACT line to stdout
+  printf 'ARTIFACT: adversarial-run|%s %s exit=%d\n' \
+    "$cmd_name" "$findings_clean" "$exit_code"
+}
+
+main "$@"

--- a/.claude/hooks/bin/freeze.sh
+++ b/.claude/hooks/bin/freeze.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# freeze.sh — Manage the /freeze path-scope lock for Claude Copilot
+#
+# The freeze lock restricts Edit, Write, and Bash redirects to a single
+# directory. This prevents accidental out-of-scope edits when working on
+# a focused sub-tree (Karpathy "orthogonal edits" failure mode).
+#
+# Usage:
+#   freeze.sh on <directory>   Lock edits to <directory> (absolute path resolved)
+#   freeze.sh off              Remove the freeze lock
+#   freeze.sh status           Show current freeze state
+#
+# Escape hatch:
+#   export COPILOT_FREEZE=off  Bypass the freeze rule for this shell session
+#   export COPILOT_SAFETY=off  Bypass ALL safety rules (/careful + /freeze)
+#
+# State file: .claude/hooks/state/.freeze (gitignored, one absolute path per line)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)" \
+  || { echo "[freeze] could not resolve SCRIPT_DIR" >&2; exit 1; }
+STATE_DIR="$(dirname "$SCRIPT_DIR")/state"
+FREEZE_FILE="${STATE_DIR}/.freeze"
+
+case "${1:-}" in
+  on)
+    dir="${2:-}"
+    if [[ -z "$dir" ]]; then
+      echo "Usage: freeze.sh on <directory>" >&2
+      exit 1
+    fi
+    # Resolve to absolute path
+    dir="$(cd "$dir" 2>/dev/null && pwd)" \
+      || { echo "[freeze] directory not found: ${2}" >&2; exit 1; }
+    printf '%s\n' "$dir" > "$FREEZE_FILE"
+    echo "Freeze ON: edits locked to ${dir}"
+    echo "  Bypass: export COPILOT_FREEZE=off"
+    echo "  Remove: .claude/hooks/bin/freeze.sh off"
+    ;;
+  off)
+    rm -f "$FREEZE_FILE"
+    echo "Freeze OFF: edits are now unrestricted"
+    ;;
+  status)
+    if [[ ! -f "$FREEZE_FILE" ]]; then
+      echo "Freeze: OFF (no lock active)"
+    else
+      local_dir=""
+      read -r local_dir < "$FREEZE_FILE" 2>/dev/null || local_dir=""
+      if [[ -z "$local_dir" ]]; then
+        echo "Freeze: OFF (empty state file)"
+      else
+        echo "Freeze: ON — locked to ${local_dir}"
+        echo "  Remove: .claude/hooks/bin/freeze.sh off"
+        echo "  Bypass: export COPILOT_FREEZE=off"
+      fi
+    fi
+    ;;
+  *)
+    echo "Usage: freeze.sh on <directory> | off | status" >&2
+    echo ""
+    echo "  on <dir>   Lock edits to <dir> (and its subdirectories)"
+    echo "  off        Remove the freeze lock"
+    echo "  status     Show current freeze state"
+    echo ""
+    echo "Environment overrides:"
+    echo "  COPILOT_FREEZE=off   Bypass for this shell session"
+    echo "  COPILOT_SAFETY=off   Bypass all safety rules"
+    exit 1
+    ;;
+esac

--- a/.claude/hooks/bin/test-adversarial-pass.sh
+++ b/.claude/hooks/bin/test-adversarial-pass.sh
@@ -1,0 +1,542 @@
+#!/usr/bin/env bash
+# test-adversarial-pass.sh — Tests for adversarial-pass.sh + subagent-stop.sh parser
+#
+# Sections:
+#   1. ABSENT path — no CLI configured/on PATH → no-op, exit 0, no output
+#   2. PRESENT path — stub model → emits ARTIFACT: adversarial-run line
+#   3. Timeout path — slow stub → degrades to no-op, exit 0
+#   4. Error path — failing stub → degrades to no-op, exit 0
+#   5. Empty diff path → no-op, exit 0
+#   6. Escape hatch — COPILOT_ADVERSARIAL=off → no-op
+#   7. Parser regression — existing artifact types (test-run, file-check, diff-check)
+#   8. Parser: adversarial-run recognized as valid type
+#   9. Parser: bare VERDICT: APPROVED (no artifact) still fails
+#  10. QA gate still unblocks on test-run alone (no adversarial artifact required)
+#
+# Usage:
+#   .claude/hooks/bin/test-adversarial-pass.sh
+#
+# Exit codes:
+#   0 — all tests passed
+#   1 — one or more tests failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+ADVERSARIAL_SCRIPT="${SCRIPT_DIR}/adversarial-pass.sh"
+SUBAGENT_STOP="${SCRIPT_DIR}/../subagent-stop.sh"
+STATE_DIR="${SCRIPT_DIR}/../state"
+GATE_FILE="${STATE_DIR}/qa-gate.json"
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_exit() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" -eq "$expected" ]]; then
+    pass "[exit=${expected}] ${label}"
+  else
+    fail "[exit=${actual}, want ${expected}] ${label}"
+  fi
+}
+
+assert_empty() {
+  local label="$1" value="$2"
+  if [[ -z "$value" ]]; then
+    pass "[empty output] ${label}"
+  else
+    fail "[unexpected output: '${value}'] ${label}"
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -q "$needle" 2>/dev/null; then
+    pass "[contains '${needle}'] ${label}"
+  else
+    fail "[missing '${needle}' in: '${haystack}'] ${label}"
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if ! printf '%s' "$haystack" | grep -q "$needle" 2>/dev/null; then
+    pass "[does not contain '${needle}'] ${label}"
+  else
+    fail "[unexpectedly contains '${needle}' in: '${haystack}'] ${label}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Stub model factory
+# ---------------------------------------------------------------------------
+TMP_DIR="$(mktemp -d 2>/dev/null)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+  # Remove any test sessions from the gate file
+  if [[ -f "$GATE_FILE" ]]; then
+    local tmp="${GATE_FILE}.test-cleanup.tmp"
+    /usr/bin/jq 'with_entries(select(.key | startswith("test-adversarial-") | not))' \
+      "$GATE_FILE" > "$tmp" 2>/dev/null && mv "$tmp" "$GATE_FILE" || true
+  fi
+}
+trap cleanup EXIT
+
+# Stub: success — outputs a FINDINGS line
+STUB_OK="${TMP_DIR}/fake-model-ok"
+cat > "$STUB_OK" << 'STUBEOF'
+#!/usr/bin/env bash
+# Reads combined prompt+diff from stdin, outputs a FINDINGS line
+input="$(cat)"
+echo "FINDINGS: no critical issues found (adversarial-stub)"
+exit 0
+STUBEOF
+chmod +x "$STUB_OK"
+
+# Stub: timeout — sleeps much longer than any test timeout
+STUB_SLOW="${TMP_DIR}/fake-model-slow"
+cat > "$STUB_SLOW" << 'STUBEOF'
+#!/usr/bin/env bash
+sleep 120
+echo "FINDINGS: too late"
+exit 0
+STUBEOF
+chmod +x "$STUB_SLOW"
+
+# Stub: error — exits non-zero
+STUB_FAIL="${TMP_DIR}/fake-model-fail"
+cat > "$STUB_FAIL" << 'STUBEOF'
+#!/usr/bin/env bash
+echo "error: API key not configured" >&2
+exit 1
+STUBEOF
+chmod +x "$STUB_FAIL"
+
+# Stub: outputs findings without the FINDINGS: prefix
+STUB_NOFIND="${TMP_DIR}/fake-model-nofind"
+cat > "$STUB_NOFIND" << 'STUBEOF'
+#!/usr/bin/env bash
+echo "The diff looks clean, no issues."
+exit 0
+STUBEOF
+chmod +x "$STUB_NOFIND"
+
+# Sample diff for use in tests
+SAMPLE_DIFF="--- a/foo.py
++++ b/foo.py
+@@ -1,3 +1,4 @@
+ def greet(name):
+-    return 'Hello ' + name
++    msg = 'Hello ' + name
++    return msg
+"
+
+# ---------------------------------------------------------------------------
+# Helper: run has_artifact_marker pattern (mirrors subagent-stop.sh exactly)
+# ---------------------------------------------------------------------------
+has_artifact_marker() {
+  local msg="$1"
+  printf '%s' "$msg" | grep -qiE \
+    '^[[:space:]]*ARTIFACT:[[:space:]]+(test-run|file-check|diff-check|adversarial-run)\|.+$'
+}
+
+# ---------------------------------------------------------------------------
+# Helper: invoke subagent-stop.sh with a fake QA payload
+# Returns exit code; sets GATE_VERDICT to "pass"|"fail"|"unknown"
+# ---------------------------------------------------------------------------
+invoke_subagent_stop_qa() {
+  local session_id="$1" last_msg="$2"
+  local payload
+  payload="$(printf '{"session_id":"%s","agent_type":"qa","last_assistant_message":%s}' \
+    "$session_id" "$(printf '%s' "$last_msg" | /usr/bin/python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")"
+  printf '%s' "$payload" | COPILOT_QA_GATE=on bash "$SUBAGENT_STOP" 2>/dev/null
+  return $?
+}
+
+# ---------------------------------------------------------------------------
+# Helper: invoke subagent-stop.sh with a fake @agent-me payload
+# ---------------------------------------------------------------------------
+invoke_subagent_stop_me() {
+  local session_id="$1" last_msg="$2"
+  local payload
+  payload="$(printf '{"session_id":"%s","agent_type":"me","last_assistant_message":%s}' \
+    "$session_id" "$(printf '%s' "$last_msg" | /usr/bin/python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")"
+  printf '%s' "$payload" | COPILOT_QA_GATE=on bash "$SUBAGENT_STOP" 2>/dev/null
+  return $?
+}
+
+# ---------------------------------------------------------------------------
+# Get pending tasks for a session from gate file
+# ---------------------------------------------------------------------------
+get_pending_tasks() {
+  local session_id="$1"
+  if [[ ! -f "$GATE_FILE" ]]; then
+    echo "[]"
+    return
+  fi
+  /usr/bin/jq -r --arg sid "$session_id" '.[$sid].pending_tasks // [] | length' "$GATE_FILE" 2>/dev/null || echo "0"
+}
+
+get_last_event() {
+  local session_id="$1"
+  if [[ ! -f "$GATE_FILE" ]]; then
+    echo "none"
+    return
+  fi
+  /usr/bin/jq -r --arg sid "$session_id" \
+    '.[$sid].history // [] | if length > 0 then .[-1].event else "none" end' \
+    "$GATE_FILE" 2>/dev/null || echo "none"
+}
+
+# ---------------------------------------------------------------------------
+# SECTION 1: ABSENT PATH (primary — this machine has no second model CLI)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Section 1: ABSENT path (no CLI configured, none on PATH) ==="
+
+# T1: No COPILOT_ADVERSARIAL_CMD, no candidates on PATH → exit 0, no output
+output="$(printf '%s' "$SAMPLE_DIFF" | \
+  env COPILOT_ADVERSARIAL_CMD="" PATH="/usr/bin:/bin" \
+  bash "$ADVERSARIAL_SCRIPT" 2>/dev/null)"
+exit_code=$?
+assert_exit "absent-path: exits 0" 0 $exit_code
+assert_empty "absent-path: no output on stdout" "$output"
+
+# T2: No env var and PATH does not contain codex/llm/mods → same no-op
+output="$(printf '%s' "$SAMPLE_DIFF" | \
+  env -i HOME="$HOME" PATH="/usr/bin:/bin" \
+  bash "$ADVERSARIAL_SCRIPT" 2>/dev/null)"
+exit_code=$?
+assert_exit "absent-path (clean env): exits 0" 0 $exit_code
+assert_empty "absent-path (clean env): no output" "$output"
+
+# T3: COPILOT_ADVERSARIAL_CMD set to a command not on PATH → no-op
+output="$(printf '%s' "$SAMPLE_DIFF" | \
+  env COPILOT_ADVERSARIAL_CMD="nonexistent-model-xyz-42" \
+  bash "$ADVERSARIAL_SCRIPT" 2>/dev/null)"
+exit_code=$?
+assert_exit "absent-path (cmd not on PATH): exits 0" 0 $exit_code
+assert_empty "absent-path (cmd not on PATH): no output" "$output"
+
+# T4: Absent path must NOT emit any ARTIFACT line
+assert_not_contains "absent-path: no ARTIFACT line emitted" "ARTIFACT" "${output}"
+
+# ---------------------------------------------------------------------------
+# SECTION 2: PRESENT PATH (stub model configured)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Section 2: PRESENT path (stub model via COPILOT_ADVERSARIAL_CMD) ==="
+
+# T5: Stub model configured → exits 0 and emits ARTIFACT line
+output="$(printf '%s' "$SAMPLE_DIFF" | \
+  env COPILOT_ADVERSARIAL_CMD="$STUB_OK" \
+  bash "$ADVERSARIAL_SCRIPT" 2>/dev/null)"
+exit_code=$?
+assert_exit "present-path (stub): exits 0" 0 $exit_code
+assert_contains "present-path: ARTIFACT line emitted" "ARTIFACT:" "$output"
+assert_contains "present-path: type is adversarial-run" "adversarial-run" "$output"
+assert_contains "present-path: exit=0 in artifact detail" "exit=0" "$output"
+
+# T6: FINDINGS: line from stub is captured in artifact
+assert_contains "present-path: FINDINGS content in artifact" "FINDINGS" "$output"
+
+# T7: No trailing newlines / clean single line
+line_count="$(printf '%s' "$output" | grep -c 'ARTIFACT:' || true)"
+if [[ "$line_count" -eq 1 ]]; then
+  pass "present-path: exactly one ARTIFACT line"
+else
+  fail "present-path: expected 1 ARTIFACT line, got ${line_count}"
+fi
+
+# T8: Stub with no FINDINGS: prefix → falls back to first non-empty line
+output_nofind="$(printf '%s' "$SAMPLE_DIFF" | \
+  env COPILOT_ADVERSARIAL_CMD="$STUB_NOFIND" \
+  bash "$ADVERSARIAL_SCRIPT" 2>/dev/null)"
+exit_nofind=$?
+assert_exit "present-path (no-FINDINGS prefix): exits 0" 0 $exit_nofind
+assert_contains "present-path (no-FINDINGS prefix): still emits ARTIFACT" "ARTIFACT:" "$output_nofind"
+
+# ---------------------------------------------------------------------------
+# SECTION 3: TIMEOUT PATH
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Section 3: Timeout path (slow stub, 1-second timeout) ==="
+
+# T9: Slow stub with short timeout → no-op (exits 0, no output)
+output_slow="$(printf '%s' "$SAMPLE_DIFF" | \
+  env COPILOT_ADVERSARIAL_CMD="$STUB_SLOW" \
+  COPILOT_ADVERSARIAL_TIMEOUT="1" \
+  bash "$ADVERSARIAL_SCRIPT" 2>/dev/null)"
+exit_slow=$?
+assert_exit "timeout-path: exits 0 (degraded to no-op)" 0 $exit_slow
+assert_empty "timeout-path: no output on stdout" "$output_slow"
+
+# ---------------------------------------------------------------------------
+# SECTION 4: ERROR PATH
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Section 4: Error path (stub exits non-zero) ==="
+
+# T10: Failing stub → no-op (exits 0, no output)
+output_fail="$(printf '%s' "$SAMPLE_DIFF" | \
+  env COPILOT_ADVERSARIAL_CMD="$STUB_FAIL" \
+  bash "$ADVERSARIAL_SCRIPT" 2>/dev/null)"
+exit_fail=$?
+assert_exit "error-path: exits 0 (degraded to no-op)" 0 $exit_fail
+assert_empty "error-path: no output on stdout" "$output_fail"
+
+# ---------------------------------------------------------------------------
+# SECTION 5: EMPTY DIFF
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Section 5: Empty diff → no-op ==="
+
+# T11: Empty diff with working stub → no-op (nothing to review)
+output_empty="$(printf '' | \
+  env COPILOT_ADVERSARIAL_CMD="$STUB_OK" \
+  bash "$ADVERSARIAL_SCRIPT" 2>/dev/null)"
+exit_empty=$?
+assert_exit "empty-diff: exits 0" 0 $exit_empty
+assert_empty "empty-diff: no output" "$output_empty"
+
+# T12: Whitespace-only diff → no-op
+output_ws="$(printf '   \n\t\n   \n' | \
+  env COPILOT_ADVERSARIAL_CMD="$STUB_OK" \
+  bash "$ADVERSARIAL_SCRIPT" 2>/dev/null)"
+exit_ws=$?
+assert_exit "whitespace-diff: exits 0" 0 $exit_ws
+assert_empty "whitespace-diff: no output" "$output_ws"
+
+# ---------------------------------------------------------------------------
+# SECTION 6: ESCAPE HATCH
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Section 6: COPILOT_ADVERSARIAL=off escape hatch ==="
+
+# T13: COPILOT_ADVERSARIAL=off → no-op even when stub is configured
+output_esc="$(printf '%s' "$SAMPLE_DIFF" | \
+  env COPILOT_ADVERSARIAL_CMD="$STUB_OK" COPILOT_ADVERSARIAL=off \
+  bash "$ADVERSARIAL_SCRIPT" 2>/dev/null)"
+exit_esc=$?
+assert_exit "escape-hatch: exits 0" 0 $exit_esc
+assert_empty "escape-hatch: no output" "$output_esc"
+
+# ---------------------------------------------------------------------------
+# SECTION 7: PARSER REGRESSION — existing artifact types unchanged
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Section 7: Parser regression — existing types still recognized ==="
+
+# These tests mirror the has_artifact_marker grep pattern in subagent-stop.sh
+# exactly (copied here so a future change to the pattern fails both tests).
+
+# T14: test-run still recognized
+if has_artifact_marker 'ARTIFACT: test-run|pytest tests/ exit=0 "5 passed"'; then
+  pass "parser: test-run recognized"
+else
+  fail "parser: test-run NOT recognized (REGRESSION)"
+fi
+
+# T15: file-check still recognized
+if has_artifact_marker 'ARTIFACT: file-check|.claude/agents/manifest.json exists agents=15'; then
+  pass "parser: file-check recognized"
+else
+  fail "parser: file-check NOT recognized (REGRESSION)"
+fi
+
+# T16: diff-check still recognized
+if has_artifact_marker 'ARTIFACT: diff-check|expected 15 actual 15 match'; then
+  pass "parser: diff-check recognized"
+else
+  fail "parser: diff-check NOT recognized (REGRESSION)"
+fi
+
+# T17: Case-insensitive recognition (capital ARTIFACT:)
+if has_artifact_marker 'ARTIFACT: test-run|some detail here'; then
+  pass "parser: case-insensitive ARTIFACT: prefix"
+else
+  fail "parser: case-insensitive ARTIFACT: prefix (REGRESSION)"
+fi
+
+# T18: Leading whitespace still works
+if has_artifact_marker '  ARTIFACT: file-check|foo.txt exists'; then
+  pass "parser: leading whitespace allowed"
+else
+  fail "parser: leading whitespace NOT handled (REGRESSION)"
+fi
+
+# T19: No detail after pipe → NOT recognized (type|<detail> requires non-empty detail)
+if ! has_artifact_marker 'ARTIFACT: test-run|'; then
+  pass "parser: empty detail after pipe not recognized"
+else
+  fail "parser: empty detail after pipe was incorrectly recognized"
+fi
+
+# T20: Unknown type → NOT recognized
+if ! has_artifact_marker 'ARTIFACT: random-type|some detail'; then
+  pass "parser: unknown type not recognized"
+else
+  fail "parser: unknown type was incorrectly recognized"
+fi
+
+# T21: Missing pipe delimiter → NOT recognized
+if ! has_artifact_marker 'ARTIFACT: test-run some detail without pipe'; then
+  pass "parser: missing pipe delimiter not recognized"
+else
+  fail "parser: missing pipe was incorrectly recognized"
+fi
+
+# ---------------------------------------------------------------------------
+# SECTION 8: adversarial-run recognized by parser
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Section 8: adversarial-run recognized by parser (new) ==="
+
+# T22: adversarial-run is now a valid type
+if has_artifact_marker 'ARTIFACT: adversarial-run|llm FINDINGS: none found exit=0'; then
+  pass "parser: adversarial-run recognized"
+else
+  fail "parser: adversarial-run NOT recognized"
+fi
+
+# T23: adversarial-run with uppercase
+if has_artifact_marker 'ARTIFACT: ADVERSARIAL-RUN|codex FINDINGS: potential NPE exit=0'; then
+  pass "parser: adversarial-run case-insensitive"
+else
+  fail "parser: adversarial-run case-insensitive NOT handled"
+fi
+
+# T24: adversarial-run with minimal detail
+if has_artifact_marker 'ARTIFACT: adversarial-run|x'; then
+  pass "parser: adversarial-run with minimal detail"
+else
+  fail "parser: adversarial-run with minimal detail not recognized"
+fi
+
+# T25: Verify the output of adversarial-pass.sh (stub present) parses correctly
+artifact_line="$(printf '%s' "$SAMPLE_DIFF" | \
+  env COPILOT_ADVERSARIAL_CMD="$STUB_OK" \
+  bash "$ADVERSARIAL_SCRIPT" 2>/dev/null)"
+if [[ -n "$artifact_line" ]] && has_artifact_marker "$artifact_line"; then
+  pass "parser: adversarial-pass.sh output parses as valid artifact"
+else
+  fail "parser: adversarial-pass.sh output '${artifact_line}' did NOT parse as valid artifact"
+fi
+
+# ---------------------------------------------------------------------------
+# SECTION 9: Gate integration — QA still unblocks on test-run alone
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Section 9: QA gate — test-run alone still unblocks (no adversarial required) ==="
+
+TEST_SESSION="test-adversarial-$$"
+
+# Step 1: Simulate @agent-me completing TASK-999 (adds to pending)
+invoke_subagent_stop_me "$TEST_SESSION" \
+  "Task: TASK-999 | WP: WP-1
+Files Modified:
+- src/foo.py: Added greet function
+Summary: Implementation complete." || true
+
+pending_after_me="$(get_pending_tasks "$TEST_SESSION")"
+if [[ "$pending_after_me" -eq 1 ]]; then
+  pass "gate-integration: TASK-999 added to pending_tasks after me_completed"
+else
+  fail "gate-integration: expected 1 pending task after me_completed, got ${pending_after_me}"
+fi
+
+# Step 2: QA passes with ONLY a test-run artifact (no adversarial artifact)
+invoke_subagent_stop_qa "$TEST_SESSION" \
+  "Task: TASK-999 | WP: WP-2
+Test Coverage:
+- Unit: 3 test cases
+Summary: All tests pass.
+ARTIFACT: test-run|pytest tests/test_foo.py exit=0 \"3 passed\"
+VERDICT: APPROVED" || true
+
+pending_after_qa="$(get_pending_tasks "$TEST_SESSION")"
+last_event="$(get_last_event "$TEST_SESSION")"
+
+if [[ "$pending_after_qa" -eq 0 ]]; then
+  pass "gate-integration: gate cleared by test-run artifact alone (no adversarial required)"
+else
+  fail "gate-integration: gate NOT cleared; pending=${pending_after_qa}, last_event=${last_event}"
+fi
+
+# T27: Verify last event was qa_passed
+if printf '%s' "$last_event" | grep -q "qa_passed"; then
+  pass "gate-integration: last event is qa_passed"
+else
+  fail "gate-integration: last event was '${last_event}', expected qa_passed"
+fi
+
+# ---------------------------------------------------------------------------
+# SECTION 10: Gate integration — adversarial-run alone also unblocks
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Section 10: QA gate — adversarial-run artifact alone also unblocks ==="
+
+TEST_SESSION2="test-adversarial-adv-$$"
+
+# Simulate me_completed for TASK-998
+invoke_subagent_stop_me "$TEST_SESSION2" \
+  "Task: TASK-998 complete." || true
+
+# QA passes with ONLY an adversarial-run artifact
+invoke_subagent_stop_qa "$TEST_SESSION2" \
+  "Task: TASK-998 | WP: WP-3
+ARTIFACT: adversarial-run|llm FINDINGS: none found exit=0
+VERDICT: APPROVED" || true
+
+pending_adv="$(get_pending_tasks "$TEST_SESSION2")"
+if [[ "$pending_adv" -eq 0 ]]; then
+  pass "gate-integration: adversarial-run artifact alone also clears the gate"
+else
+  fail "gate-integration: adversarial-run artifact alone did NOT clear gate; pending=${pending_adv}"
+fi
+
+# ---------------------------------------------------------------------------
+# SECTION 11: Bare VERDICT: APPROVED with NO artifact still fails
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Section 11: Bare VERDICT: APPROVED (no artifact) still fails ==="
+
+TEST_SESSION3="test-adversarial-bare-$$"
+
+invoke_subagent_stop_me "$TEST_SESSION3" \
+  "Task: TASK-997 complete." || true
+
+invoke_subagent_stop_qa "$TEST_SESSION3" \
+  "Task: TASK-997 | WP: WP-4
+VERDICT: APPROVED" || true
+
+pending_bare="$(get_pending_tasks "$TEST_SESSION3")"
+if [[ "$pending_bare" -eq 1 ]]; then
+  pass "gate-integration: bare VERDICT: APPROVED (no artifact) does NOT unblock gate"
+else
+  fail "gate-integration: bare VERDICT: APPROVED incorrectly unblocked gate (pending should be 1, got ${pending_bare})"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "==================================================================="
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo "==================================================================="
+
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/.claude/hooks/bin/test-safety-rules.sh
+++ b/.claude/hooks/bin/test-safety-rules.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# test-safety-rules.sh — Integration tests for the safety primitives in pretool-check.sh
+#
+# Tests: rule_destructive_command (/careful) and rule_path_scope (/freeze)
+#
+# Usage:
+#   .claude/hooks/bin/test-safety-rules.sh
+#
+# Exit codes:
+#   0 — all tests passed
+#   1 — one or more tests failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+HOOK="${SCRIPT_DIR}/../pretool-check.sh"
+STATE_DIR="${SCRIPT_DIR}/../state"
+FREEZE_FILE="${STATE_DIR}/.freeze"
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+# invoke_hook <payload_json> → sets HOOK_EXIT and HOOK_STDOUT and HOOK_STDERR
+invoke_hook() {
+  local payload="$1"
+  HOOK_STDOUT="$(printf '%s' "$payload" | COPILOT_FORCE_DELEGATE=off COPILOT_QA_GATE=off \
+    bash "$HOOK" 2>/tmp/test-safety-stderr)"
+  HOOK_EXIT=$?
+  HOOK_STDERR="$(cat /tmp/test-safety-stderr 2>/dev/null || true)"
+}
+
+assert_exit() {
+  local test_name="$1" expected="$2"
+  if [[ "$HOOK_EXIT" -eq "$expected" ]]; then
+    echo "  PASS [exit=${expected}]: ${test_name}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL [exit=${HOOK_EXIT}, want ${expected}]: ${test_name}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_stdout_contains() {
+  local test_name="$1" needle="$2"
+  if printf '%s' "$HOOK_STDOUT" | grep -q "$needle" 2>/dev/null; then
+    echo "  PASS [stdout contains '${needle}']: ${test_name}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL [stdout='${HOOK_STDOUT}', want '${needle}']: ${test_name}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_stderr_contains() {
+  local test_name="$1" needle="$2"
+  if printf '%s' "$HOOK_STDERR" | grep -q "$needle" 2>/dev/null; then
+    echo "  PASS [stderr contains '${needle}']: ${test_name}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL [stderr='${HOOK_STDERR}', want '${needle}']: ${test_name}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Unique session ID for tests (avoids affecting real sessions)
+TEST_SESSION="test-safety-rules-$$"
+
+# Build a Bash tool payload
+bash_payload() {
+  local cmd="$1"
+  printf '{"session_id":"%s","tool_name":"Bash","tool_input":{"command":"%s"}}' \
+    "$TEST_SESSION" "$(printf '%s' "$cmd" | sed 's/"/\\"/g')"
+}
+
+# Build an Edit tool payload
+edit_payload() {
+  local file_path="$1"
+  printf '{"session_id":"%s","tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"a","new_string":"b"}}' \
+    "$TEST_SESSION" "$file_path"
+}
+
+# Build a Write tool payload
+write_payload() {
+  local file_path="$1"
+  printf '{"session_id":"%s","tool_name":"Write","tool_input":{"file_path":"%s","content":"test"}}' \
+    "$TEST_SESSION" "$file_path"
+}
+
+# ---------------------------------------------------------------------------
+# Teardown: clean freeze state + streak state after tests
+# ---------------------------------------------------------------------------
+cleanup() {
+  rm -f "$FREEZE_FILE"
+  rm -f "${STATE_DIR}/streak-${TEST_SESSION}.json"
+  rm -f /tmp/test-safety-stderr
+}
+trap cleanup EXIT
+
+# Remove any leftover freeze state from a previous aborted test run
+rm -f "$FREEZE_FILE"
+
+# ---------------------------------------------------------------------------
+# SECTION 1: rule_destructive_command (/careful)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== /careful (rule_destructive_command) ==="
+
+# T1: Block — git push --force (block severity)
+invoke_hook "$(bash_payload "git push origin main --force")"
+assert_exit "git push --force is blocked" 2
+assert_stdout_contains "git push --force stdout has deny reason" "permissionDecision"
+
+# T2: Block — git push -f (common shorthand)
+invoke_hook "$(bash_payload "git push -f")"
+assert_exit "git push -f is blocked" 2
+
+# T3: Block — git push origin -f (with remote arg)
+invoke_hook "$(bash_payload "git push origin -f")"
+assert_exit "git push origin -f is blocked" 2
+
+# T4: Warn — rm -rf / (warn severity — destructive-command rule)
+invoke_hook "$(bash_payload "rm -rf /")"
+assert_exit "rm -rf / exits 0 (warn, not block)" 0
+assert_stderr_contains "rm -rf / emits safety-warn to stderr" "safety-warn"
+
+# T5: Warn — git reset --hard
+invoke_hook "$(bash_payload "git reset --hard HEAD~1")"
+assert_exit "git reset --hard exits 0 (warn)" 0
+assert_stderr_contains "git reset --hard emits safety-warn" "safety-warn"
+
+# T6: Warn — DROP TABLE
+invoke_hook "$(bash_payload "psql -c 'DROP TABLE users;'")"
+assert_exit "DROP TABLE exits 0 (warn)" 0
+assert_stderr_contains "DROP TABLE emits safety-warn" "safety-warn"
+
+# T7: Allow — normal command (ls)
+invoke_hook "$(bash_payload "ls -la /tmp")"
+assert_exit "ls -la is allowed (exit 0)" 0
+
+# T8: Allow — git push without --force
+invoke_hook "$(bash_payload "git push origin main")"
+assert_exit "git push origin main is allowed" 0
+
+# T9: Escape hatch — COPILOT_CAREFUL=off bypasses block
+HOOK_STDOUT="$(printf '%s' "$(bash_payload "git push --force")" | \
+  COPILOT_FORCE_DELEGATE=off COPILOT_QA_GATE=off COPILOT_CAREFUL=off \
+  bash "$HOOK" 2>/tmp/test-safety-stderr)"
+HOOK_EXIT=$?
+if [[ "$HOOK_EXIT" -eq 0 ]]; then
+  echo "  PASS [exit=0]: COPILOT_CAREFUL=off bypasses git push --force block"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL [exit=${HOOK_EXIT}, want 0]: COPILOT_CAREFUL=off should bypass block"
+  FAIL=$((FAIL + 1))
+fi
+
+# T10: Escape hatch — COPILOT_SAFETY=off bypasses block
+HOOK_STDOUT="$(printf '%s' "$(bash_payload "git push --force")" | \
+  COPILOT_FORCE_DELEGATE=off COPILOT_QA_GATE=off COPILOT_SAFETY=off \
+  bash "$HOOK" 2>/tmp/test-safety-stderr)"
+HOOK_EXIT=$?
+if [[ "$HOOK_EXIT" -eq 0 ]]; then
+  echo "  PASS [exit=0]: COPILOT_SAFETY=off bypasses git push --force block"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL [exit=${HOOK_EXIT}, want 0]: COPILOT_SAFETY=off should bypass block"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# SECTION 2: rule_path_scope (/freeze)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== /freeze (rule_path_scope) ==="
+
+FREEZE_DIR="/tmp/test-freeze-$$"
+mkdir -p "$FREEZE_DIR"
+cleanup_freeze_dir() { rm -rf "$FREEZE_DIR"; }
+trap "cleanup_freeze_dir; cleanup" EXIT
+
+# Set up freeze state
+printf '%s\n' "$FREEZE_DIR" > "$FREEZE_FILE"
+
+# T11: Allow — Edit inside freeze dir
+invoke_hook "$(edit_payload "${FREEZE_DIR}/foo.txt")"
+assert_exit "Edit inside freeze dir is allowed" 0
+
+# T12: Block — Edit outside freeze dir
+invoke_hook "$(edit_payload "/tmp/outside-project/bar.txt")"
+assert_exit "Edit outside freeze dir is blocked" 2
+assert_stdout_contains "Edit outside freeze has deny reason" "permissionDecision"
+
+# T13: Allow — Write inside freeze dir
+invoke_hook "$(write_payload "${FREEZE_DIR}/subdir/file.txt")"
+assert_exit "Write inside freeze dir is allowed" 0
+
+# T14: Block — Write outside freeze dir
+invoke_hook "$(write_payload "/etc/hosts")"
+assert_exit "Write outside freeze dir (/etc/hosts) is blocked" 2
+
+# T15: Allow — Bash without redirect (no path violation)
+invoke_hook "$(bash_payload "ls -la ${FREEZE_DIR}")"
+assert_exit "Bash ls inside freeze dir is allowed" 0
+
+# T16: Block — Bash redirect to outside-freeze path
+invoke_hook "$(bash_payload "echo hello > /tmp/outside.txt")"
+assert_exit "Bash redirect outside freeze dir is blocked" 2
+
+# T17: Allow — Bash redirect to inside-freeze path
+invoke_hook "$(bash_payload "echo hello > ${FREEZE_DIR}/output.txt")"
+assert_exit "Bash redirect inside freeze dir is allowed" 0
+
+# T18: Escape hatch — COPILOT_FREEZE=off bypasses freeze block
+HOOK_STDOUT="$(printf '%s' "$(edit_payload "/tmp/outside-project/bar.txt")" | \
+  COPILOT_FORCE_DELEGATE=off COPILOT_QA_GATE=off COPILOT_FREEZE=off \
+  bash "$HOOK" 2>/tmp/test-safety-stderr)"
+HOOK_EXIT=$?
+if [[ "$HOOK_EXIT" -eq 0 ]]; then
+  echo "  PASS [exit=0]: COPILOT_FREEZE=off bypasses freeze block"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL [exit=${HOOK_EXIT}, want 0]: COPILOT_FREEZE=off should bypass freeze"
+  FAIL=$((FAIL + 1))
+fi
+
+# T19: Escape hatch — COPILOT_SAFETY=off bypasses freeze
+HOOK_STDOUT="$(printf '%s' "$(write_payload "/etc/hosts")" | \
+  COPILOT_FORCE_DELEGATE=off COPILOT_QA_GATE=off COPILOT_SAFETY=off \
+  bash "$HOOK" 2>/tmp/test-safety-stderr)"
+HOOK_EXIT=$?
+if [[ "$HOOK_EXIT" -eq 0 ]]; then
+  echo "  PASS [exit=0]: COPILOT_SAFETY=off bypasses freeze block"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL [exit=${HOOK_EXIT}, want 0]: COPILOT_SAFETY=off should bypass freeze"
+  FAIL=$((FAIL + 1))
+fi
+
+# T20: No freeze file — no restriction
+rm -f "$FREEZE_FILE"
+invoke_hook "$(edit_payload "/tmp/outside-project/bar.txt")"
+assert_exit "No freeze file → no restriction on outside path" 0
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "==================================================================="
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo "==================================================================="
+
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/.claude/hooks/bin/test-subagent-stop.sh
+++ b/.claude/hooks/bin/test-subagent-stop.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# test-subagent-stop.sh — Integration tests for subagent-stop.sh QA gate logic
+#
+# Tests:
+#   - Normal me completion activates QA gate (pending_tasks populated)
+#   - BLOCKED me completion does NOT activate QA gate
+#   - CONFUSED me completion does NOT activate QA gate
+#   - CONFUSED is a recognized terminal promise (gate stays clear)
+#   - QA pass clears pending_tasks
+#
+# Usage:
+#   .claude/hooks/bin/test-subagent-stop.sh
+#
+# Exit codes:
+#   0 — all tests passed
+#   1 — one or more tests failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+HOOK="${SCRIPT_DIR}/../subagent-stop.sh"
+STATE_DIR="${SCRIPT_DIR}/../state"
+GATE_FILE="${STATE_DIR}/qa-gate.json"
+LOG_FILE="${STATE_DIR}/qa-gate.log"
+JQ="/usr/bin/jq"
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+# Unique session ID per test run to avoid cross-contamination
+TEST_SESSION="test-subagent-stop-$$"
+
+# invoke_hook <payload_json> → sets HOOK_EXIT and HOOK_STDOUT
+invoke_hook() {
+  local payload="$1"
+  HOOK_STDOUT="$(printf '%s' "$payload" | bash "$HOOK" 2>/dev/null)"
+  HOOK_EXIT=$?
+}
+
+assert_exit() {
+  local test_name="$1" expected="$2"
+  if [[ "$HOOK_EXIT" -eq "$expected" ]]; then
+    echo "  PASS [exit=${expected}]: ${test_name}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL [exit=${HOOK_EXIT}, want ${expected}]: ${test_name}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Assert that a TASK-N is in pending_tasks for TEST_SESSION
+assert_in_pending() {
+  local test_name="$1" task_id="$2"
+  if [[ ! -f "$GATE_FILE" ]]; then
+    echo "  FAIL [gate file missing]: ${test_name}"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  local found
+  found="$("$JQ" -r --arg sid "$TEST_SESSION" --arg tid "$task_id" \
+    '.[$sid].pending_tasks // [] | map(. == $tid) | any' "$GATE_FILE" 2>/dev/null || echo "false")"
+  if [[ "$found" == "true" ]]; then
+    echo "  PASS [${task_id} in pending_tasks]: ${test_name}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL [${task_id} NOT in pending_tasks, want it there]: ${test_name}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Assert that a TASK-N is NOT in pending_tasks for TEST_SESSION
+assert_not_in_pending() {
+  local test_name="$1" task_id="$2"
+  if [[ ! -f "$GATE_FILE" ]]; then
+    # No gate file means nothing was added — that's a pass
+    echo "  PASS [gate file absent → ${task_id} not pending]: ${test_name}"
+    PASS=$((PASS + 1))
+    return
+  fi
+  local found
+  found="$("$JQ" -r --arg sid "$TEST_SESSION" --arg tid "$task_id" \
+    '.[$sid].pending_tasks // [] | map(. == $tid) | any' "$GATE_FILE" 2>/dev/null || echo "false")"
+  if [[ "$found" == "false" ]]; then
+    echo "  PASS [${task_id} not in pending_tasks]: ${test_name}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL [${task_id} IS in pending_tasks, should NOT be]: ${test_name}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Build a SubagentStop payload for agent-me
+me_payload() {
+  local msg="$1"
+  printf '{"session_id":"%s","agent_type":"me","last_assistant_message":"%s"}' \
+    "$TEST_SESSION" "$(printf '%s' "$msg" | sed 's/"/\\"/g')"
+}
+
+# Build a SubagentStop payload for agent-qa
+qa_payload() {
+  local msg="$1"
+  printf '{"session_id":"%s","agent_type":"qa","last_assistant_message":"%s"}' \
+    "$TEST_SESSION" "$(printf '%s' "$msg" | sed 's/"/\\"/g')"
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+cleanup() {
+  # Remove only the test session from the gate file (leave other sessions intact)
+  if [[ -f "$GATE_FILE" ]]; then
+    local cleaned
+    cleaned="$("$JQ" --arg sid "$TEST_SESSION" 'del(.[$sid])' "$GATE_FILE" 2>/dev/null || cat "$GATE_FILE")"
+    printf '%s\n' "$cleaned" > "${GATE_FILE}.tmp.$$"
+    mv "${GATE_FILE}.tmp.$$" "$GATE_FILE" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# SECTION 1: Normal completion — should activate QA gate
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Normal me completion (should activate QA gate) ==="
+
+MSG_NORMAL="Task: TASK-42 | WP: WP-10\nFiles Modified:\n- src/auth.py: Added login\nSummary: Implemented login flow.\n<promise>COMPLETE</promise>"
+
+invoke_hook "$(me_payload "$MSG_NORMAL")"
+assert_exit "Normal completion exits 0" 0
+assert_in_pending "Normal completion adds TASK-42 to pending_tasks" "TASK-42"
+
+# ---------------------------------------------------------------------------
+# SECTION 2: BLOCKED me completion — must NOT activate QA gate
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== BLOCKED me completion (must NOT activate QA gate) ==="
+
+MSG_BLOCKED="Working on TASK-99. The planned approach requires X but X is unavailable.\nQUESTION: Should we use approach Y instead?\n<promise>BLOCKED</promise>"
+
+invoke_hook "$(me_payload "$MSG_BLOCKED")"
+assert_exit "BLOCKED completion exits 0" 0
+assert_not_in_pending "BLOCKED completion does NOT add TASK-99 to pending_tasks" "TASK-99"
+
+# ---------------------------------------------------------------------------
+# SECTION 3: CONFUSED me completion — must NOT activate QA gate
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== CONFUSED me completion (must NOT activate QA gate) ==="
+
+MSG_CONFUSED="Working on TASK-77. Hit a genuine decision fork mid-implementation.\n<promise>CONFUSED</promise>\nQUESTION: Should the cache key include the user tenant or not?\nOPTIONS:\n- A: Include tenant in cache key (safe, lower hit rate)\n- B: Shared cache key (higher hit rate, may leak cross-tenant data)\nCONTEXT: Affects both correctness and performance."
+
+invoke_hook "$(me_payload "$MSG_CONFUSED")"
+assert_exit "CONFUSED completion exits 0" 0
+assert_not_in_pending "CONFUSED completion does NOT add TASK-77 to pending_tasks" "TASK-77"
+
+# ---------------------------------------------------------------------------
+# SECTION 4: Verify CONFUSED is a terminal promise distinct from COMPLETE
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== CONFUSED terminal promise — gate stays clear after CONFUSED ==="
+
+# A fresh task that gets CONFUSED (not previously queued)
+MSG_CONFUSED_FRESH="Implementing TASK-55. Need user decision before proceeding.\n<promise>CONFUSED</promise>\nQUESTION: Use REST or GraphQL for this endpoint?\nOPTIONS:\n- A: REST\n- B: GraphQL\nCONTEXT: Determines client contract."
+
+invoke_hook "$(me_payload "$MSG_CONFUSED_FRESH")"
+assert_exit "CONFUSED fresh task exits 0" 0
+assert_not_in_pending "CONFUSED fresh TASK-55 not added to pending_tasks" "TASK-55"
+
+# After CONFUSED, if user answers and me is re-invoked normally, gate should work
+MSG_AFTER_CONFUSED="Task: TASK-55 | WP: WP-55\nImplemented REST endpoint per user decision.\n<promise>COMPLETE</promise>"
+
+invoke_hook "$(me_payload "$MSG_AFTER_CONFUSED")"
+assert_exit "Post-CONFUSED normal completion exits 0" 0
+assert_in_pending "Post-CONFUSED normal TASK-55 IS added to pending_tasks" "TASK-55"
+
+# ---------------------------------------------------------------------------
+# SECTION 5: Escape hatch — COPILOT_QA_GATE=off bypasses everything
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Escape hatch: COPILOT_QA_GATE=off ==="
+
+# Reset the test session state to verify escape hatch independently
+cleanup
+
+MSG_ESCAPE="Task: TASK-88 complete. <promise>COMPLETE</promise>"
+HOOK_STDOUT="$(printf '%s' "$(me_payload "$MSG_ESCAPE")" | COPILOT_QA_GATE=off bash "$HOOK" 2>/dev/null)"
+HOOK_EXIT=$?
+if [[ "$HOOK_EXIT" -eq 0 ]]; then
+  echo "  PASS [exit=0]: COPILOT_QA_GATE=off exits 0"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL [exit=${HOOK_EXIT}, want 0]: COPILOT_QA_GATE=off should exit 0"
+  FAIL=$((FAIL + 1))
+fi
+assert_not_in_pending "COPILOT_QA_GATE=off: TASK-88 not added (hook disabled)" "TASK-88"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "==================================================================="
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo "==================================================================="
+
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/.claude/hooks/pretool-check.sh
+++ b/.claude/hooks/pretool-check.sh
@@ -55,6 +55,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)" \
   || { echo "[pretool-check] could not resolve SCRIPT_DIR" >&2; exit 0; }
 STATE_DIR="${SCRIPT_DIR}/state"
 MANIFEST_FILE="${SCRIPT_DIR}/../agents/manifest.json"
+SECURITY_RULES_FILE="${SCRIPT_DIR}/security-rules.json"
+FREEZE_STATE_FILE="${STATE_DIR}/.freeze"
 JQ="/usr/bin/jq"
 
 # ---------------------------------------------------------------------------
@@ -403,9 +405,146 @@ rule_qa_gate() {
 }
 
 # ---------------------------------------------------------------------------
+# Rule: destructive-command (/careful)
+# Reads enabled rules from security-rules.json and tests the Bash command
+# string against each rule's patterns (case-insensitive).
+# - action "block" → deny (exit 2)
+# - action "warn"  → emit warning to stderr, allow (exit 0)
+# Only applies to the Bash tool. A single jq call processes all rules.
+# Bypass: COPILOT_SAFETY=off or COPILOT_CAREFUL=off
+# ---------------------------------------------------------------------------
+rule_destructive_command() {
+  if [[ "${COPILOT_SAFETY:-}" == "off" || "${COPILOT_CAREFUL:-}" == "off" ]]; then
+    return 0
+  fi
+
+  # Only applies to Bash tool
+  if [[ "$TOOL_NAME" != "Bash" ]]; then
+    return 0
+  fi
+
+  local cmd
+  cmd="$("$JQ" -r '.tool_input.command // ""' <<< "$PAYLOAD" 2>/dev/null)" \
+    || { echo "[pretool-check] jq parse failed reading command in rule_destructive_command" >&2; return 0; }
+  [[ -z "$cmd" ]] && return 0
+
+  [[ ! -f "$SECURITY_RULES_FILE" ]] && return 0
+
+  # Two jq calls: first checks "block" rules, then "warn" rules.
+  # Using inline filters (no def) for maximal jq version compatibility.
+  # IMPORTANT: patterns are captured via "as $pat" so test($pat;"i") uses the
+  # pattern as regex; $cmd is the string being matched against each pattern.
+  local block_name
+  block_name="$("$JQ" -r --arg cmd "$cmd" '
+    [.rules[] |
+     select(.enabled == true and .action == "block") |
+     . as $rule |
+     $rule.patterns[] as $pat |
+     select(($cmd | test($pat; "i")) == true) |
+     $rule.name
+    ][0] // ""
+  ' "$SECURITY_RULES_FILE" 2>/dev/null)" \
+    || { echo "[pretool-check] jq failed (block check) in rule_destructive_command" >&2; return 0; }
+
+  if [[ -n "$block_name" ]]; then
+    deny "Safety (/careful): '${block_name}' — command blocked to prevent irreversible damage. Set COPILOT_CAREFUL=off to bypass if intentional."
+    return  # not reached; deny calls exit 2
+  fi
+
+  local warn_name
+  warn_name="$("$JQ" -r --arg cmd "$cmd" '
+    [.rules[] |
+     select(.enabled == true and .action == "warn") |
+     . as $rule |
+     $rule.patterns[] as $pat |
+     select(($cmd | test($pat; "i")) == true) |
+     $rule.name
+    ][0] // ""
+  ' "$SECURITY_RULES_FILE" 2>/dev/null)" \
+    || { echo "[pretool-check] jq failed (warn check) in rule_destructive_command" >&2; return 0; }
+
+  if [[ -n "$warn_name" ]]; then
+    echo "[safety-warn] /careful: '${warn_name}' — command matches a destructive pattern. Review before executing. Set COPILOT_CAREFUL=off to suppress this warning." >&2
+  fi
+
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Rule: path-scope (/freeze)
+# When a freeze directory is configured in FREEZE_STATE_FILE, denies any
+# Edit, Write, or Bash-redirect operation targeting a path outside that dir.
+#
+# State file: .claude/hooks/state/.freeze (plain text, one absolute path)
+# Enable:  echo /your/project/dir > .claude/hooks/state/.freeze
+#          (or use: .claude/hooks/bin/freeze.sh on /your/project/dir)
+# Disable: rm .claude/hooks/state/.freeze
+#          (or use: .claude/hooks/bin/freeze.sh off)
+#
+# For Edit/Write: checks file_path in tool_input (exact, reliable).
+# For Bash: checks redirect targets (> path or >> path) outside freeze dir.
+# Bypass: COPILOT_SAFETY=off or COPILOT_FREEZE=off
+# ---------------------------------------------------------------------------
+rule_path_scope() {
+  if [[ "${COPILOT_SAFETY:-}" == "off" || "${COPILOT_FREEZE:-}" == "off" ]]; then
+    return 0
+  fi
+
+  # Only applies to Edit, Write, Bash
+  case "$TOOL_NAME" in
+    Edit|Write|Bash) ;;
+    *) return 0 ;;
+  esac
+
+  # Read freeze dir — if state file missing or empty, no freeze active
+  [[ ! -f "$FREEZE_STATE_FILE" ]] && return 0
+  local freeze_dir
+  read -r freeze_dir < "$FREEZE_STATE_FILE" 2>/dev/null || freeze_dir=""
+  freeze_dir="${freeze_dir%/}"  # strip trailing slash
+  [[ -z "$freeze_dir" ]] && return 0
+
+  case "$TOOL_NAME" in
+    Edit|Write)
+      local file_path
+      file_path="$("$JQ" -r '.tool_input.file_path // ""' <<< "$PAYLOAD" 2>/dev/null)" \
+        || { echo "[pretool-check] jq parse failed reading file_path in rule_path_scope" >&2; return 0; }
+      [[ -z "$file_path" ]] && return 0
+      file_path="${file_path%/}"  # normalize
+      if [[ "$file_path" != "${freeze_dir}"* ]]; then
+        deny "Freeze (/freeze): edits are locked to '${freeze_dir}'. '${file_path}' is outside the freeze boundary. Use COPILOT_FREEZE=off to bypass, or run: .claude/hooks/bin/freeze.sh off"
+      fi
+      ;;
+    Bash)
+      local cmd
+      cmd="$("$JQ" -r '.tool_input.command // ""' <<< "$PAYLOAD" 2>/dev/null)" \
+        || { echo "[pretool-check] jq parse failed reading command in rule_path_scope" >&2; return 0; }
+      [[ -z "$cmd" ]] && return 0
+
+      # Extract redirect targets (> path and >> path) from the command.
+      # This is a best-effort check: it catches explicit file redirects.
+      # Use grep to find paths after > or >> operators.
+      local redirect_target
+      redirect_target="$(printf '%s' "$cmd" | grep -oE '>{1,2}[[:space:]]*/[^[:space:]|;&]+' \
+        2>/dev/null | grep -oE '/[^[:space:]|;&]+' | head -1 || true)"
+
+      if [[ -n "$redirect_target" ]]; then
+        redirect_target="${redirect_target%/}"
+        if [[ "$redirect_target" != "${freeze_dir}"* ]]; then
+          deny "Freeze (/freeze): writes are locked to '${freeze_dir}'. Redirect target '${redirect_target}' is outside the freeze boundary. Use COPILOT_FREEZE=off to bypass."
+        fi
+      fi
+      ;;
+  esac
+
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # Dispatch — rule sets run in order; first deny wins
 # ---------------------------------------------------------------------------
 rule_force_delegate
 rule_qa_gate
+rule_destructive_command
+rule_path_scope
 
 exit 0

--- a/.claude/hooks/security-rules.json
+++ b/.claude/hooks/security-rules.json
@@ -27,7 +27,7 @@
     {
       "id": "destructive-command",
       "name": "Destructive Command Detection",
-      "description": "Warns on destructive commands like rm -rf, DROP TABLE, etc.",
+      "description": "Warns on destructive commands like rm -rf, DROP TABLE, git reset --hard, etc.",
       "enabled": true,
       "priority": 85,
       "patterns": [
@@ -40,10 +40,27 @@
         "DELETE\\s+FROM\\s+\\w+\\s*;",
         "shutdown|reboot|halt",
         "mkfs|dd\\s+if=",
-        "chmod\\s+777"
+        "chmod\\s+777",
+        "git\\s+reset\\s+--hard",
+        "git\\s+clean\\s+.*-[a-zA-Z]*f[a-zA-Z]*",
+        "chmod\\s+-R"
       ],
       "action": "warn",
       "severity": "high"
+    },
+    {
+      "id": "git-force-push",
+      "name": "Git Force Push Detection",
+      "description": "Blocks irreversible git force-push operations that overwrite remote history",
+      "enabled": true,
+      "priority": 92,
+      "patterns": [
+        "git\\s+push\\s+.*--force",
+        "git\\s+push\\s+-[a-zA-Z]*f(\\s|$)",
+        "git\\s+push\\s+\\S+\\s.*-[a-zA-Z]*f(\\s|$)"
+      ],
+      "action": "block",
+      "severity": "critical"
     },
     {
       "id": "sensitive-file-protection",

--- a/.claude/hooks/subagent-stop.sh
+++ b/.claude/hooks/subagent-stop.sh
@@ -34,6 +34,13 @@
 # LOG FILE:
 #   .claude/hooks/state/qa-gate.log — warnings for missing task IDs etc.
 #
+# ADVERSARIAL PASS (TASK-131):
+#   Optional second-model "try to break this diff" pass.  When a configured CLI
+#   is present, @agent-qa can run `.claude/hooks/bin/adversarial-pass.sh` and
+#   include the emitted ARTIFACT: adversarial-run|... line in its verdict.
+#   Configure via COPILOT_ADVERSARIAL_CMD env var or auto-probe (codex/llm/mods).
+#   When no CLI is present the script is a clean no-op — gate never blocked.
+#
 # ESCAPE HATCH:
 #   Set COPILOT_QA_GATE=off to disable all QA gate state management.
 #
@@ -198,10 +205,16 @@ extract_all_task_ids() {
 #   4. <promise>COMPLETE</promise> with no REJECTED AND an ARTIFACT marker → implicit pass
 #   5. Otherwise → unknown (treated as fail for safety)
 #
-# ARTIFACT marker format (R3 WS1 / TASK-115):
+# ARTIFACT marker format (R3 WS1 / TASK-115, extended TASK-131):
 #   ARTIFACT: <type>|<detail>
-#   where type ∈ {test-run, file-check, diff-check}
+#   where type ∈ {test-run, file-check, diff-check, adversarial-run}
 #   Example: ARTIFACT: test-run|pytest tests/foo.py exit=0 "3 passed"
+#   Example: ARTIFACT: adversarial-run|llm FINDINGS: none found exit=0
+#
+# adversarial-run is OPTIONAL / bonus — emitted by adversarial-pass.sh when a
+# second-model CLI is available.  It satisfies the artifact requirement on its
+# own but is never a NEW mandatory requirement.  The gate still passes on any
+# single recognized artifact type (e.g. test-run alone is sufficient).
 #
 # ESCAPE HATCH:
 #   COPILOT_QA_GATE=off bypasses all gate logic in the caller (subagent-stop.sh).
@@ -211,8 +224,11 @@ extract_all_task_ids() {
 has_artifact_marker() {
   local msg="$1"
   # Case-insensitive match for ARTIFACT: <type>|<detail>
-  # type must be one of: test-run, file-check, diff-check
-  printf '%s' "$msg" | grep -qiE '^[[:space:]]*ARTIFACT:[[:space:]]+(test-run|file-check|diff-check)\|.+$'
+  # type must be one of: test-run, file-check, diff-check, adversarial-run
+  # adversarial-run added in TASK-131 (availability-gated; optional/bonus type).
+  # Adding it here is ADDITIVE — existing types are unchanged; the new type
+  # satisfies the artifact requirement but is never a mandatory gate of its own.
+  printf '%s' "$msg" | grep -qiE '^[[:space:]]*ARTIFACT:[[:space:]]+(test-run|file-check|diff-check|adversarial-run)\|.+$'
 }
 
 parse_qa_verdict() {
@@ -259,6 +275,24 @@ parse_qa_verdict() {
 # Handle @agent-me completion
 # ---------------------------------------------------------------------------
 handle_me_completion() {
+  # Guard: BLOCKED and CONFUSED are non-completion terminal states.
+  # Neither represents a finished implementation that needs QA review:
+  #   <promise>BLOCKED</promise> — external/technical blocker; agent cannot proceed
+  #   <promise>CONFUSED</promise> — decision fork that requires user input
+  # In both cases, skip the QA gate so the signal surfaces to the user.
+  if printf '%s' "$LAST_MSG" | grep -qF '<promise>BLOCKED</promise>'; then
+    local blocked_task
+    blocked_task="$(extract_task_id "$LAST_MSG")"
+    log_info "me_completed with BLOCKED promise — skipping QA gate for ${blocked_task:-unknown} (session: ${SESSION_ID})"
+    exit 0
+  fi
+  if printf '%s' "$LAST_MSG" | grep -qF '<promise>CONFUSED</promise>'; then
+    local confused_task
+    confused_task="$(extract_task_id "$LAST_MSG")"
+    log_info "me_completed with CONFUSED promise — skipping QA gate for ${confused_task:-unknown} (session: ${SESSION_ID})"
+    exit 0
+  fi
+
   local task_id
   task_id="$(extract_task_id "$LAST_MSG")"
 

--- a/.claude/memory/entries/1b26912d-7d2a-4cbe-b76c-b85afb8e254d.md
+++ b/.claude/memory/entries/1b26912d-7d2a-4cbe-b76c-b85afb8e254d.md
@@ -1,0 +1,10 @@
+---
+id: 1b26912d-7d2a-4cbe-b76c-b85afb8e254d
+type: decision
+tags: []
+created: 2026-06-17T13:06:14Z
+updated: 2026-06-17T13:06:14Z
+scope: project
+---
+
+PRD-7 Phase 1 complete on branch feat/prd-7-verification-and-observability. manifest.json=15 framework agents+kc setup-only. validation_result.py at .claude/hooks/lib/. Banner generated from manifest. 28/28 tests pass. Phase 2 streams (WS1/WS2/WS3) can now proceed in parallel.

--- a/.claude/memory/entries/27aee711-22b6-4942-9b8f-c85e56f29b02.md
+++ b/.claude/memory/entries/27aee711-22b6-4942-9b8f-c85e56f29b02.md
@@ -1,0 +1,10 @@
+---
+id: 27aee711-22b6-4942-9b8f-c85e56f29b02
+type: decision
+tags: []
+created: 2026-06-17T19:22:27Z
+updated: 2026-06-17T19:22:27Z
+scope: project
+---
+
+Framework 5.10.0 fleet sync complete 2026-06-17: 25 repos processed, 24 merged+pushed to default branch directly, 1 protected (h3/Hermes-3 needs PR to main). Dirty repos (flow, saas-financial-model, tracker) had WIP committed before sync — all recoverable. Delphi and pipeline-copilot had diverged remotes — resolved via merge. method-copilot was on demo branch — committed WIP, checked out main, pulled 16 upstream commits, merged. All sync branches cleaned up. Spot-checks: manifest.json and owner:project invariants intact.

--- a/.claude/memory/entries/2a980add-3f20-407b-b666-ae4b48ad829b.md
+++ b/.claude/memory/entries/2a980add-3f20-407b-b666-ae4b48ad829b.md
@@ -1,0 +1,10 @@
+---
+id: 2a980add-3f20-407b-b666-ae4b48ad829b
+type: decision
+tags: []
+created: 2026-06-17T13:46:28Z
+updated: 2026-06-17T13:46:28Z
+scope: project
+---
+
+WS3 R1 finding: Claude Code OAuth token endpoint is api.anthropic.com with Bearer auth; probe model must be claude-haiku-4-5 (claude-haiku-3-5-20241022 returns 404 on oauth endpoint). Actual ratelimit headers: anthropic-ratelimit-unified-5h/7d/overage-status/utilization/reset + representative-claim + fallback-percentage. Verified 2026-06-17.

--- a/.claude/memory/entries/3d0505ec-7531-4d59-92d7-0f664ab41fc8.md
+++ b/.claude/memory/entries/3d0505ec-7531-4d59-92d7-0f664ab41fc8.md
@@ -1,0 +1,10 @@
+---
+id: 3d0505ec-7531-4d59-92d7-0f664ab41fc8
+type: decision
+tags: []
+created: 2026-06-17T13:13:40Z
+updated: 2026-06-17T13:13:40Z
+scope: project
+---
+
+PRD-7 WS1 artifact marker format: ARTIFACT: <type>|<detail> where type in {test-run, file-check, diff-check}. Defined in qa.md and enforced in subagent-stop.sh has_artifact_marker(). Bare VERDICT: APPROVED without ARTIFACT returns fail. WARNING_HALT_THRESHOLD=3 in sec.md.

--- a/.claude/memory/entries/5cc1b7e9-c86b-464b-947a-4e7331e61e22.md
+++ b/.claude/memory/entries/5cc1b7e9-c86b-464b-947a-4e7331e61e22.md
@@ -1,0 +1,10 @@
+---
+id: 5cc1b7e9-c86b-464b-947a-4e7331e61e22
+type: decision
+tags: []
+created: 2026-06-25T19:15:56Z
+updated: 2026-06-25T19:15:56Z
+scope: project
+---
+
+TASK-129 safety primitives: rule_destructive_command + rule_path_scope wired into pretool-check.sh. Key bug: jq def f(action) with filter args caused .action==action to always match; fixed with two inline jq queries using hardcoded strings. Escape hatches: COPILOT_CAREFUL=off, COPILOT_FREEZE=off, COPILOT_SAFETY=off. Freeze state: .claude/hooks/state/.freeze. Helper: .claude/hooks/bin/freeze.sh. 25/25 tests pass.

--- a/.claude/memory/entries/ab7f5740-4576-4c5f-b8fe-833d01dfb624.md
+++ b/.claude/memory/entries/ab7f5740-4576-4c5f-b8fe-833d01dfb624.md
@@ -1,0 +1,10 @@
+---
+id: ab7f5740-4576-4c5f-b8fe-833d01dfb624
+type: decision
+tags: []
+created: 2026-06-17T19:09:19Z
+updated: 2026-06-17T19:09:19Z
+scope: project
+---
+
+5.10.0 fleet sync complete: 22 repos pushed to chore/copilot-5.10.0-sync. 3 repos skipped (flow, saas-financial-model, tracker) — WIP touches .claude/, require manual merge. All WIP confirmed safe. WP-149.

--- a/.claude/memory/entries/c00b1337-4204-4047-bbfc-80986e508984.md
+++ b/.claude/memory/entries/c00b1337-4204-4047-bbfc-80986e508984.md
@@ -1,0 +1,10 @@
+---
+id: c00b1337-4204-4047-bbfc-80986e508984
+type: decision
+tags: [architecture, cc-usage, framework-hardening, manifest, qa-gate]
+created: 2026-06-17T12:55:49Z
+updated: 2026-06-17T12:55:49Z
+scope: project
+---
+
+Framework Hardening initiative (PRD-7, TASK-112..125). 3 ADRs: (1) QA gate must bind PASS to an external artifact (test cmd+exit+output / file-shape / diff-vs-spec) — introspection is not a check; gate logic in subagent-stop.sh::parse_qa_verdict. (2) ONE .claude/agents/manifest.json as roster/routing source of truth; GENERATE SessionStart banner + force-delegate agent list from it — fixes stale banner (protocol-injection.md L12 listed retired 'design' + setup-only 'kc') and VERSION.json frameworkAgents drift (wrongly counts kc among the 16). (3) cc usage probe MUST be idle-gated — a /v1/messages probe opens a fresh 5h window, naive polling corrupts the number; producer(CLI)/consumer(statusline) split + atomic cache + transcript-reconstruction fallback. Sequencing: WS4 foundation FIRST (manifest + structured-validation-result pattern) because WS1 builds artifact-gating on it and both touch the QA-gate hook. WS1/WS2/WS3 parallel after. cc doctor.py is a CONFIG doctor — WS2 adds a DISTINCT 'cc memory check'.

--- a/.claude/memory/entries/c88faa21-5f49-48c0-aaa3-0979bd79b6b0.md
+++ b/.claude/memory/entries/c88faa21-5f49-48c0-aaa3-0979bd79b6b0.md
@@ -1,0 +1,10 @@
+---
+id: c88faa21-5f49-48c0-aaa3-0979bd79b6b0
+type: decision
+tags: []
+created: 2026-06-25T18:24:49Z
+updated: 2026-06-25T18:24:49Z
+scope: project
+---
+
+External-source eval (gstack + Anthropic 'Effectiveness of HTML') stored as WP-151 on task 23. Top adoptions for Copilot: P0=HTML work-product renderer 'tc wp render --html' with 'copy as' JSON/MD buttons (novel, token-free side artifact, fits externalize-don't-inline core purpose); P1=wire already-scaffolded but unwired security-rules.json into pretool-check.sh as /careful (destructive-cmd) + /freeze (path-scope) rules (low cost, closes self-documented gap, defends Karpathy orthogonal-edits); P1=availability-gated cross-model adversarial QA/sec pass feeding a new ARTIFACT type into subagent-stop verdict parser (strongest possible artifact, must degrade gracefully offline). SKIP: gstack [gstack-context] WIP-commit checkpoints (duplicates memory+pause/continue, pollutes git history we keep clean via PR), /retro vanity LOC metrics (conflicts No-Time-Estimates; cc usage already covers telemetry), cross-agent Codex/Cursor portability (hooks are CC-native by design).

--- a/.claude/memory/entries/ff680af0-c470-4e58-88e6-614ba44f5361.md
+++ b/.claude/memory/entries/ff680af0-c470-4e58-88e6-614ba44f5361.md
@@ -1,0 +1,10 @@
+---
+id: ff680af0-c470-4e58-88e6-614ba44f5361
+type: decision
+tags: []
+created: 2026-06-17T18:30:52Z
+updated: 2026-06-17T18:30:52Z
+scope: project
+---
+
+Framework 5.10.0 fleet sync complete (2026-06-17). 15 git repos updated on branch chore/copilot-5.10.0-sync (unpushed), 9 dirty repos skipped (flow, method-copilot, n8n-copilot, project-copilot, saas-financial-model, the-collective, thought-leadership, runway, tracker, Delphi), playground files-only. voice-copilot cco.md owner:project preserved. Pre-existing FF1 failure in voice-copilot (@agent-cmo ref in commands not caused by sync). h3 had orchestrator dir removed. WP-148.

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ PROJECT_MAP.md
 .claude/hooks/state/*.json
 .claude/hooks/state/*.lock
 .claude/hooks/state/*.tmp.*
+.claude/hooks/state/.freeze
 
 # Local/generated artifacts
 .claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.11.0] - 2026-06-25
+
+Safety primitives, cross-model adversarial QA, CONFUSED loop-state, HTML work-product renderer, and `cc memory export`. Inspired in part by **gstack** (Garry Tan, `github.com/garrytan/gstack`, MIT) and **"The Unreasonable Effectiveness of HTML"** (Thariq Shihipar, Anthropic Engineering Blog) — see ADR-004.
+
+### Added
+
+- **HTML work-product renderer** (`tools/tc/src/tc/services/render_html.py`, `tc wp render <id> --html`): renders any work product to a fully self-contained HTML file at `.copilot/renders/WP-<id>.html` (inline CSS, vanilla JS, no CDN). Token-free side artifact — the CLI prints only the absolute file path; the HTML body never enters the context window. Auto-detects three templates: severity (P0/P1/P2/CRITICAL/HIGH/MEDIUM/LOW color-coding + legend), variant-grid (≥ 2 option/variant/approach headings → tabbed comparison), and rendered-diff (` ```diff ` block or ≥ 3 diff lines → syntax-highlighted viewer). All renders include "Copy as Markdown" and "Copy as JSON" buttons. Zero new PyPI dependencies. Inspired by gstack's `/design-html` side-artifact pattern and the HTML-output-with-copy-buttons approach from Thariq Shihipar's Anthropic blog post.
+- **Safety primitives — `/careful` and `/freeze`** (`.claude/hooks/pretool-check.sh`, `.claude/hooks/security-rules.json`, `.claude/hooks/bin/freeze.sh`): two new PreToolUse rule functions. `/careful` (`rule_destructive_command`) reads `security-rules.json` at runtime and blocks (`action: block`, exit 2) or warns (`action: warn`, stderr + exit 0) on matching Bash commands (patterns include `git push --force`, `rm -rf`, `git reset --hard`, `git clean -f`, `chmod -R`). `/freeze` (`rule_path_scope`) locks Edit/Write/Bash to a declared directory tree (state: `.claude/hooks/state/.freeze`; managed via `.claude/hooks/bin/freeze.sh on|off|status`). Escape hatches: `COPILOT_CAREFUL=off`, `COPILOT_FREEZE=off`, `COPILOT_SAFETY=off` (disables both). Inspired by gstack's `/careful` and `/freeze` primitives; reimplemented natively in bash/jq.
+- **Cross-model adversarial QA pass** (`.claude/hooks/bin/adversarial-pass.sh`): optional "try to break this diff" pass that @agent-qa can run after its own verification. Availability-gated: checks `COPILOT_ADVERSARIAL_CMD` env var, then PATH-probes for `codex`, `llm`, `mods`; clean no-op if none found. New `adversarial-run` ARTIFACT type recognized by `subagent-stop.sh` alongside `test-run`, `file-check`, `diff-check` — satisfies the artifact requirement on its own but is never a new mandatory gate. Config: `COPILOT_ADVERSARIAL_CMD`, `COPILOT_ADVERSARIAL_TIMEOUT` (default 30 s), `COPILOT_ADVERSARIAL=off`. Inspired by gstack's cross-model adversarial review (`/codex` second-opinion pass); reimplemented natively.
+- **`<promise>CONFUSED</promise>` loop-state** (`CLAUDE.md`, `me.md`, `ta.md`, `do.md`, `sec.md`, `qa.md`, `subagent-stop.sh`): in-flight decision-point signal for agents that hit a genuine decision fork requiring user judgment. Distinct from `<promise>BLOCKED</promise>` (technical blocker / unmet dependency). When emitted, `subagent-stop.sh` surfaces it to the user instead of activating the QA gate. Added to `completionPromises` in all agents that carry BLOCKED. Inspired by gstack's Confusion Protocol; adapted to the Copilot loop-state model.
+- **`cc memory export`** (`tools/cc/src/cc/commands/memory.py`): export memory entries to a portable Markdown or JSON bundle. `cc memory export` (all entries, Markdown); `--json` (JSON array); positional query (keyword-filtered via FTS); `--type` (type-filtered); `--all` (explicit all); `--out <path>` (write to file). Type and keyword filters compose.
+
+### Changed
+
+- **CLAUDE.md**: added `tc wp render <id> --html` to Task Copilot commands; added `cc memory export` to memory commands; updated Testing Gate to list `adversarial-run` as a fourth ARTIFACT type; added safety primitives (`/careful`, `/freeze`, escape hatches) to the Main Session Guardrails enforcement paragraph; CONFUSED and Confused Loop-State already present from prior me-agent pass (no change)
+- **`tools/tc/README.md`**: added `tc wp render` to the `tc wp` command section; added HTML rendering template reference table; added `render_html.py` to layout
+- **`tools/cc/README.md`**: added `cc memory export` examples to the Memory section; updated layout to reflect `export` in `memory.py`
+- **`.claude/hooks/README.md`**: safety primitives, adversarial pass, and CONFUSED/BLOCKED guards documented in prior me-agent pass (no change needed)
+- **tc component**: `render_html.py` added; `wp.py` extended with `render` subcommand; `api.py` exports `render_wp_html`
+- **cc component**: `memory.py` extended with `export` subcommand
+- **Agents component**: `me.md`, `ta.md`, `do.md`, `sec.md`, `qa.md` updated with `<promise>CONFUSED</promise>` in `completionPromises`
+
+### Attribution
+
+- **gstack** by Garry Tan (`github.com/garrytan/gstack`, MIT) — inspiration for `/careful`+`/freeze` safety primitives, cross-model adversarial review, the `/design-html` side-artifact pattern, and the Confusion Protocol. Concepts adopted natively; no code copied.
+- **"The Unreasonable Effectiveness of HTML"** by Thariq Shihipar (Anthropic Engineering Blog) — inspiration for HTML-as-output-format with "Copy as Markdown/JSON" buttons and variant-grid comparison layouts. Concepts adopted natively; no code copied.
+
+### Architecture
+
+- **ADR-004** (`docs/10-architecture/05-adr-004-html-output-format.md`): records the decision to use HTML as a work-product output format, alternatives rejected, and full attribution.
+
 ## [5.10.0] - 2026-06-17
 
 Framework hardening initiative (PRD-7): four workstreams closing drift/verification gaps — failable QA gate, memory drift detection, usage observability, and declarative agent manifest.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code when working with the Claude Copilot 
 | Avoid reading >8 files directly | Delegate to framework agent | Hook: force-delegate (triggers at 5 consecutive same-tool calls) |
 | Keep responses short | Store details via `tc wp store` | Advisory |
 
-**Mechanical enforcement:** The force-delegate rule, QA-gate rule, and session-cap advisory are enforced by hooks in `.claude/hooks/` — not just policy. Attempting >5 consecutive Bash/Read/Edit calls will be blocked automatically. After `@agent-me` completes, all main-session tools are gated until `@agent-qa` provides a pass verdict. See `.claude/hooks/README.md` for escape hatches and debug tools.
+**Mechanical enforcement:** The force-delegate rule, QA-gate rule, session-cap advisory, and safety primitives are enforced by hooks in `.claude/hooks/` — not just policy. Attempting >5 consecutive Bash/Read/Edit calls will be blocked automatically. After `@agent-me` completes, all main-session tools are gated until `@agent-qa` provides a pass verdict. **Safety primitives:** `/careful` (destructive-command block/warn via `security-rules.json`) and `/freeze` (edit-boundary lock via `.claude/hooks/state/.freeze`) — escape hatches: `COPILOT_CAREFUL=off`, `COPILOT_FREEZE=off`, `COPILOT_SAFETY=off`. See `.claude/hooks/README.md` for escape hatches and debug tools.
 
 **Framework agents:** ta, me, qa, do, doc, sd · design chain sd→uxd→uids→uid→ta→me · branches ind/cco/cw · sec · business cs/cpa (15 framework agents; kc is setup-only; `design` retired). Roster is the authoritative list in `.claude/agents/manifest.json`.
 
@@ -123,7 +123,7 @@ Skills auto-fire based on their trigger-rich `description` field — native Clau
 
 Ephemeral PRD, task, and work product storage. Reduces context for externalized work products by ~94% vs inlining outputs above the 8KB threshold (not end-to-end session savings — see [derivation](docs/70-reference/04-framework-modernization-analysis.md)). Uses the `tc` CLI tool (installed at `tools/tc/`). Agents call `tc` commands via Bash.
 
-**Core Commands:** `tc prd create`, `tc task create`, `tc task update`, `tc task get`, `tc wp store`, `tc wp get`, `tc progress`
+**Core Commands:** `tc prd create`, `tc task create`, `tc task update`, `tc task get`, `tc wp store`, `tc wp get`, `tc wp render <id> --html`, `tc progress`
 
 **Stream Commands:** `tc stream list`, `tc stream get`
 
@@ -189,7 +189,7 @@ All agents inherit these. Individual agent files should NOT repeat them.
 - **Live Docs — Verify upstream APIs before coding:** Before implementing or planning against a third-party library/framework API where correctness depends on the *installed* version, run `cc docs get <pkg>` (also `cc docs resolve <pkg>` for the active version and `cc docs search <pkg> "<query>"`) instead of trusting training-data memory of that API. It returns docs for the version actually installed in the project, is local-first so it works offline/headless, and only falls back to a self-owned network fetch when the optional `httpx` extra is present.
 - **Memory — Recall at start:** Run `cc memory search "<task topic>"` to recall prior decisions, lessons, and context relevant to the current task.
 - **Memory — Store at end:** After completing meaningful work, run `cc memory store --type <decision|context|lesson|reference> "<content>"` to persist decisions and lessons for future sessions. Do NOT call it "semantic" — it is FTS5 keyword search.
-- **Memory commands:** `cc memory store`, `cc memory search`, `cc memory get`, `cc memory list` (not MCP `memory_store`/`memory_search`)
+- **Memory commands:** `cc memory store`, `cc memory search`, `cc memory get`, `cc memory list`, `cc memory export` (not MCP `memory_store`/`memory_search`)
 - **Task Copilot Pattern:** `tc task get` → do work → `tc wp store` → `tc task update --status completed`
 - **Code-Execution Path (PREFER for >=3 related ops):** When performing 3+ related tc or cc operations (create PRD + tasks, wire deps, store multiple WPs, batch memory stores), use a SINGLE `python3` Bash block importing `tc.api` or `cc.api` instead of multiple CLI calls. Each CLI round-trip echoes a full JSON payload back into context; a python3 block returns only what you `print()`.
   - tc-only block: `from tc.api import create_prd, create_task, add_dependency, transaction`
@@ -198,13 +198,22 @@ All agents inherit these. Individual agent files should NOT repeat them.
   - Keep CLI for single one-shot ops (`tc task get 40 --json`; one `tc wp store`; one `cc memory search`).
   - Token win example: PRD + 18 tasks + 17 deps = 36 CLI calls (~9-20K tokens echoed) vs one python3 block (~25 tokens returned).
   - See `tools/tc/README.md` and `tools/cc/README.md` for the full usage pattern.
-- **Iteration Loop:** Self-manage iterations (max from frontmatter). Pass → complete. Blocked → emit `<promise>BLOCKED</promise>`. Else → iterate.
+- **Iteration Loop:** Self-manage iterations (max from frontmatter). Pass → complete. Blocked → emit `<promise>BLOCKED</promise>`. Confused → emit `<promise>CONFUSED</promise>` (see Confused Loop-State). Else → iterate.
+- **Confused Loop-State:** When mid-task you hit a genuine decision fork that only the user can resolve, emit `<promise>CONFUSED</promise>` and record loop-state in a fenced block immediately after the promise tag:
+  ```
+  QUESTION: <one clear question — what decision must be made>
+  OPTIONS:
+  - A: <option description>
+  - B: <option description>
+  CONTEXT: <why the choice matters — consequences of each option>
+  ```
+  Do NOT guess. Suspend iteration and wait for the user's answer, then resume from where you stopped. **Distinct from `<promise>BLOCKED</promise>`** (technical blocker or unmet external dependency): CONFUSED is for decision forks where user judgment defines the correct path, not for missing prerequisites.
 - **Return Format:** Return ONLY ~100 tokens to main session. Store all details via `tc wp store`.
 - **Context Compaction:** If response exceeds ~14K tokens, store as work product and return summary only.
 - **Knowledge:** Run `cc memory search "<voice/brand query>"` for user-facing features. Never block work for missing knowledge.
 - **Specification Workflow:** Domain agents (sd, ind, uxd, uids, cco, cw) store as `type: 'specification'`, route to @agent-ta.
 - **Multi-Agent Handoff:** Intermediate agents: `tc handoff` then route to next agent. Final agent: `tc log --task <id>`, return consolidated summary.
-- **Testing Gate (MANDATORY):** @agent-me is NEVER final. After implementation, @agent-qa MUST run tests and include an `ARTIFACT: <type>|<detail>` marker in its verdict (`test-run`, `file-check`, or `diff-check`). A bare `VERDICT: APPROVED` with no ARTIFACT line will NOT unblock the gate. No implementation ships without QA. See `.claude/hooks/README.md` for the full verdict format.
+- **Testing Gate (MANDATORY):** @agent-me is NEVER final. After implementation, @agent-qa MUST run tests and include an `ARTIFACT: <type>|<detail>` marker in its verdict (`test-run`, `file-check`, `diff-check`, or `adversarial-run`). A bare `VERDICT: APPROVED` with no ARTIFACT line will NOT unblock the gate. `adversarial-run` satisfies the artifact requirement on its own but is never a new mandatory requirement (it is availability-gated — see `.claude/hooks/bin/adversarial-pass.sh`). No implementation ships without QA. See `.claude/hooks/README.md` for the full verdict format.
 - **Protocol Integration:** Output stage-complete summary with Task/WP IDs, key decisions, handoff context (200-char max).
 
 ---

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,20 +1,20 @@
 {
-  "framework": "5.10.0",
-  "lastUpdated": "2026-06-17T00:00:00.000Z",
+  "framework": "5.11.0",
+  "lastUpdated": "2026-06-25T00:00:00.000Z",
   "components": {
     "cc": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "path": "tools/cc",
       "installScript": "tools/cc/install.sh",
       "provides": ["cc memory", "cc memory check", "cc skill", "cc config", "cc env", "cc docs", "cc usage"]
     },
     "tc": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "path": "tools/tc",
       "installCommand": "pip install -e ~/.claude/copilot/tools/tc"
     },
     "agents": {
-      "version": "5.5.0",
+      "version": "5.6.0",
       "path": ".claude/agents",
       "count": 16,
       "_countNote": "16 total manifest entries: 15 framework agents + 1 setup-only (kc). See frameworkAgents for the authoritative list.",

--- a/docs/10-architecture/05-adr-004-html-output-format.md
+++ b/docs/10-architecture/05-adr-004-html-output-format.md
@@ -1,0 +1,85 @@
+# ADR-004: HTML as a Work-Product Output Format
+
+**Diátaxis mode:** Explanation (architectural decision record)
+
+**Status:** Accepted
+**Date:** 2026-06-25
+**Deciders:** Pablo Alejo
+**Component:** Task Copilot (`tc`) — work-product rendering
+
+---
+
+## Context
+
+Work products stored in Task Copilot carry their content as Markdown text (inline in SQLite for small payloads; file-referenced in `.copilot/wp/` above 8 KB). `tc wp get` returns this text to the context window.
+
+Two usage patterns create friction with text-only output:
+
+1. **Review mode.** QA agents and human reviewers scan adversarial reports, implementation notes, and design comparisons that contain tables, severity ladders, code diffs, and side-by-side option grids. Plain Markdown in a terminal is hard to parse visually; every call to `tc wp get` floods the context window with the full payload.
+
+2. **Attribution and handoff.** When sharing a work product outside the agent chain (peer review, async stakeholder review), Markdown requires a separate renderer. Embedding rendered output into the context window is the wrong delivery channel.
+
+### Prior art that informed this decision
+
+- **gstack by Garry Tan** (`github.com/garrytan/gstack`, MIT): introduced the `/design-html` command pattern — producing a fully self-contained HTML file as the output of a design pass rather than returning raw text. The key insight: a side-artifact file is zero-cost to generate and zero-cost to the context window.
+- **"The Unreasonable Effectiveness of HTML" by Thariq Shihipar** (Anthropic Engineering Blog): demonstrated that HTML-as-output with "Copy as Markdown/JSON" buttons and variant-comparison grids gives reviewers a richer, more navigable surface than plain text — and that this pattern fits naturally into AI-assisted workflows. Specific influences: copy-as-Markdown buttons, copy-as-JSON buttons, and variant/option grid layouts.
+
+We reimplemented both ideas natively in Python; no code was copied.
+
+---
+
+## Decision
+
+Add `tc wp render <id> --html` as a **token-free side artifact** command that:
+
+1. Reads the work product via `get_wp()` (no storage side-effects).
+2. Renders it to a fully self-contained HTML file at `.copilot/renders/WP-<id>.html` (inline CSS, vanilla JS, no CDN, no external assets).
+3. Returns only the absolute file path to stdout — the HTML body never enters the context window.
+4. Does NOT change what `tc wp get`, `list_wps`, or any storage function returns to callers.
+
+**Auto-detected templates** keep the renderer zero-configuration:
+
+| Template | Detection rule | Added capability |
+|----------|---------------|-----------------|
+| Severity | P0/P1/P2 or CRITICAL/HIGH/MEDIUM/LOW markers in content | Color-coded severity rows, legend |
+| Variant grid | ≥ 2 headings containing option/variant/alternative/approach/solution | Tabbed side-by-side comparison |
+| Rendered diff | ` ```diff ` block or ≥ 3 standalone `+`/`-` diff lines | Syntax-highlighted diff viewer |
+
+All renders include "Copy as Markdown" and "Copy as JSON" buttons (`navigator.clipboard.writeText`). Content with ≥ 100 newlines gets a Rendered / Source tab switcher.
+
+Implementation: `tools/tc/src/tc/services/render_html.py` (zero new PyPI dependencies — pure-Python line-by-line Markdown converter with `html.escape()` safety and `<script>` JSON-encoding).
+
+---
+
+## Alternatives Rejected
+
+| Alternative | Reason rejected |
+|-------------|----------------|
+| **Return rendered HTML in stdout** | Defeats the purpose — would flood the context window with 10–100 KB of markup. The value is the side-artifact pattern, not the HTML per se. |
+| **Use a third-party Markdown-to-HTML library (mistune, markdown2, etc.)** | Adds a PyPI dependency to `tc`, which is intentionally minimal. The line-by-line converter covers the subset actually used in work products (headings, tables, fenced code, bold/italic, links, lists). |
+| **Render to PDF** | Requires headless browser or WeasyPrint; heavyweight for an agent-side tool. HTML achieves the same review goal without binary dependencies. |
+| **Extend `tc wp get --html`** | Would change the contract of `tc wp get`, which callers depend on for text. A separate `render` subcommand keeps the contracts separate and makes the side-artifact nature explicit. |
+
+---
+
+## Consequences
+
+**Positive:**
+- Context window impact of rendering is zero (only a path string enters context).
+- Renders are reusable across sessions — `.copilot/renders/` persists with the project.
+- No new runtime dependencies.
+- Token-free contract is explicit: `render_wp_html` never writes to the `work_products` table.
+- The pattern extends naturally to future templates (e.g., test-results, threat-model grids) without changing the CLI surface.
+
+**Negative / risks:**
+- Renders can go stale if the work product is updated after rendering. The render path is deterministic (`WP-<id>.html`) so callers can always re-run to refresh.
+- `navigator.clipboard` requires HTTPS or localhost in modern browsers. A graceful fallback message is displayed when the API is unavailable (e.g., `file://` protocol).
+
+---
+
+## References
+
+- **gstack** by Garry Tan — `github.com/garrytan/gstack` (MIT) — inspiration for the `/design-html` side-artifact pattern, `/careful`+`/freeze` safety primitives, cross-model adversarial review, and the Confusion Protocol. We adopted the core concepts natively; no code was copied.
+- **"The Unreasonable Effectiveness of HTML"** by Thariq Shihipar (Anthropic Engineering Blog) — inspiration for HTML-as-output-format with copy-as-Markdown/JSON buttons and variant-grid layouts.
+- Implementation WPs: WP-152 (HTML renderer), WP-158 (variant-grid + rendered-diff templates)
+- CHANGELOG: 5.11.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,8 @@ Explanation-mode pages on how and why the framework is structured.
 | `10-architecture/01-agents.md` | Agent roster, capabilities, and inter-agent routing rules |
 | `10-architecture/02-philosophy.md` | Design principles: context economy, ephemerality, battle-tested workflows |
 | `10-architecture/03-decision-guide.md` | When to use which agent, command, or tool |
-| `10-architecture/04-framework-restructure-2026-04.md` | ADR: April 2026 restructure — MCP → CLI migration rationale |
+| `10-architecture/04-framework-restructure-2026-04.md` | ADR-001: April 2026 restructure — MCP → CLI migration rationale |
+| `10-architecture/05-adr-004-html-output-format.md` | ADR-004: HTML as a work-product output format — token-free side artifact, template auto-detection, attribution |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilot/framework",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "description": "Claude Copilot - AI-enabled development framework",
   "private": true,
   "scripts": {

--- a/tools/cc/README.md
+++ b/tools/cc/README.md
@@ -72,6 +72,12 @@ cc memory delete fee71a3e --yes    # skip prompt
 cc memory index --rebuild          # rebuild from files
 cc memory index --status           # check sync state
 
+# Export memory entries to a portable Markdown or JSON bundle
+cc memory export                            # all entries as Markdown (stdout)
+cc memory export --json                     # all entries as JSON array (stdout)
+cc memory export auth --type decision       # keyword-filtered, type-filtered, Markdown
+cc memory export --all --out dump.md        # write to file
+
 # Migrate from legacy copilot-memory SQLite databases
 cc memory migrate --from-global             # interactive — choose which DB
 cc memory migrate --from-global --all       # migrate all without prompting
@@ -512,7 +518,7 @@ tools/cc/
     __init__.py           # version string
     main.py               # Typer app + subgroup registration
     commands/             # one module per subcommand group
-      memory.py           # store, get, list, delete, search, index, migrate
+      memory.py           # store, get, list, delete, search, index, migrate, export
       skill.py            # list, search, get, path
       config.py           # get, set, unset, list, where, validate, edit, init, export, doctor
       env.py              # cc env (shell hydration)

--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "1.3.0"
+version = "1.5.0"
 description = "Unified CLI replacing copilot-memory and skills-copilot MCP servers"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI — unified replacement for copilot-memory and skills-copilot MCP servers."""
 
-__version__ = "1.3.0"
+__version__ = "1.5.0"

--- a/tools/cc/src/cc/api.py
+++ b/tools/cc/src/cc/api.py
@@ -232,6 +232,106 @@ def memory_search(
 
 
 # ---------------------------------------------------------------------------
+# Memory: export
+# ---------------------------------------------------------------------------
+
+
+def memory_export(
+    *,
+    query: str | None = None,
+    entry_type: str | None = None,
+    scope: str | None = None,
+    output_format: str = "markdown",
+) -> str:
+    """Export memory entries to a portable Markdown or JSON string.
+
+    Args:
+        query:         Optional keyword filter (FTS search).
+        entry_type:    Optional type filter (e.g. "decision", "lesson").
+        scope:         "project" (default in a git repo) or "global".
+        output_format: "markdown" (default) or "json".
+
+    Returns:
+        A string containing the exported entries in the requested format.
+
+    Raises:
+        EntryValidationError: if scope is invalid.
+        ValueError: if output_format is not "markdown" or "json".
+    """
+    import json as _json
+
+    if output_format not in ("markdown", "json"):
+        raise ValueError(f"output_format must be 'markdown' or 'json', got {output_format!r}")
+
+    from cc.core.entry_store import (
+        resolve_memory_root,
+        default_scope,
+        search_entries_files,
+        list_entries,
+    )
+    from cc.core.memory_index import search_index
+
+    try:
+        resolved_scope = scope or default_scope()
+    except ValueError as exc:
+        raise EntryValidationError(str(exc)) from exc
+
+    if query:
+        try:
+            memory_root = resolve_memory_root(resolved_scope)
+        except ValueError as exc:
+            raise EntryValidationError(str(exc)) from exc
+
+        results = search_index(query, memory_root)
+        used_index = bool(results) or (memory_root / "memory.db").exists()
+        if not used_index or not results:
+            results = search_entries_files(query, scope=resolved_scope)
+        if entry_type:
+            results = [e for e in results if e.get("type") == entry_type]
+    else:
+        try:
+            results = list_entries(scope=resolved_scope, entry_type=entry_type)
+        except ValueError as exc:
+            raise EntryValidationError(str(exc)) from exc
+
+    if output_format == "json":
+        return _json.dumps(results, indent=2, ensure_ascii=False)
+
+    # Markdown output
+    if not results:
+        return "# Memory Export\n\n_(no entries match the given filters)_\n"
+
+    lines: list[str] = [
+        "# Memory Export",
+        "",
+        f"Entries: {len(results)}",
+        "",
+        "---",
+        "",
+    ]
+    for entry in results:
+        eid = entry.get("id", "")
+        etype = entry.get("type", "")
+        tags = ", ".join(entry.get("tags") or []) or "(none)"
+        created = entry.get("created", "")
+        content = (entry.get("content") or "").strip()
+        lines += [
+            f"## [{eid[:8]}] {etype}",
+            "",
+            f"**ID:** {eid}  ",
+            f"**Type:** {etype}  ",
+            f"**Tags:** {tags}  ",
+            f"**Created:** {created}",
+            "",
+            content,
+            "",
+            "---",
+            "",
+        ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # Skills: get / search
 # ---------------------------------------------------------------------------
 
@@ -433,6 +533,7 @@ __all__ = [
     "memory_list",
     "memory_delete",
     "memory_search",
+    "memory_export",
     # skill ops
     "skill_get",
     "skill_search",

--- a/tools/cc/src/cc/commands/memory.py
+++ b/tools/cc/src/cc/commands/memory.py
@@ -477,6 +477,136 @@ def _migrate_entries(
 # ---------------------------------------------------------------------------
 
 
+@memory_app.command("export")
+def memory_export(
+    query: Optional[str] = typer.Argument(
+        None,
+        help="Optional keyword filter — exports only entries matching this search query.",
+    ),
+    entry_type: Optional[str] = typer.Option(
+        None,
+        "--type",
+        "-t",
+        help="Filter by type: decision|context|lesson|reference|person.",
+    ),
+    output_all: bool = typer.Option(
+        False,
+        "--all",
+        help="Export all entries (default when no query or --type is given).",
+    ),
+    output_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Export as a JSON array instead of Markdown.",
+    ),
+    out: Optional[Path] = typer.Option(
+        None,
+        "--out",
+        help="Write output to this file path instead of stdout.",
+        writable=True,
+    ),
+    scope: Optional[str] = typer.Option(None, "--scope", "-s"),
+) -> None:
+    """Export memory entries to a portable Markdown or JSON bundle.
+
+    With no arguments, exports all entries.  Provide a QUERY to filter by
+    keyword (FTS search), --type to filter by entry type, or both together.
+    Output is Markdown by default; use --json for a JSON array.
+
+    Examples:
+
+    \b
+        cc memory export                     # all entries as Markdown (stdout)
+        cc memory export --json              # all entries as JSON (stdout)
+        cc memory export auth --type decision  # filtered, Markdown
+        cc memory export --all --out dump.md   # write to file
+    """
+    resolved_scope = _resolve_scope(scope)
+
+    # Resolve entry list: keyword search first (if query), then type-filter.
+    if query:
+        try:
+            memory_root = resolve_memory_root(resolved_scope)
+        except ValueError as exc:
+            err_console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(1)
+
+        results = search_index(query, memory_root)
+        used_index = bool(results) or (memory_root / "memory.db").exists()
+        if not used_index or not results:
+            results = search_entries_files(query, scope=resolved_scope)
+
+        # Apply type filter on top of search results when both are given.
+        if entry_type:
+            results = [e for e in results if e.get("type") == entry_type]
+    else:
+        try:
+            results = list_entries(scope=resolved_scope, entry_type=entry_type)
+        except ValueError as exc:
+            err_console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(1)
+
+    if not results:
+        if output_json:
+            payload = "[]"
+        else:
+            payload = "# Memory Export\n\n_(no entries match the given filters)_\n"
+        _write_or_print(payload, out)
+        return
+
+    if output_json:
+        payload = json.dumps(results, indent=2, ensure_ascii=False)
+    else:
+        payload = _build_markdown_export(results)
+
+    _write_or_print(payload, out)
+
+
+def _build_markdown_export(entries: List[dict]) -> str:
+    """Render a list of memory entries as a portable Markdown document."""
+    lines: list[str] = [
+        "# Memory Export",
+        "",
+        f"Entries: {len(entries)}",
+        "",
+        "---",
+        "",
+    ]
+    for entry in entries:
+        eid = entry.get("id", "")
+        etype = entry.get("type", "")
+        tags = ", ".join(entry.get("tags") or []) or "(none)"
+        created = entry.get("created", "")
+        content = (entry.get("content") or "").strip()
+        lines += [
+            f"## [{eid[:8]}] {etype}",
+            "",
+            f"**ID:** {eid}  ",
+            f"**Type:** {etype}  ",
+            f"**Tags:** {tags}  ",
+            f"**Created:** {created}",
+            "",
+            content,
+            "",
+            "---",
+            "",
+        ]
+    return "\n".join(lines)
+
+
+def _write_or_print(payload: str, out: Optional[Path]) -> None:
+    """Write *payload* to *out* path or stdout."""
+    if out is not None:
+        try:
+            Path(out).write_text(payload, encoding="utf-8")
+            console.print(f"[green]Exported[/green] → {out}")
+        except OSError as exc:
+            err_console.print(f"[red]Error writing file:[/red] {exc}")
+            raise typer.Exit(1)
+    else:
+        typer.echo(payload)
+
+
 @memory_app.command("check")
 def memory_check(
     scope: Optional[str] = typer.Option(None, "--scope", "-s"),

--- a/tools/cc/tests/test_memory.py
+++ b/tools/cc/tests/test_memory.py
@@ -554,3 +554,183 @@ class TestMemoryCLI:
         monkeypatch.setattr(es, "_git_root", lambda: tmp_path)
         result = cli_runner.invoke(cli_app, ["memory", "index"])
         assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# cc memory export — CLI and API-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryExportCLI:
+    """Tests for `cc memory export` subcommand."""
+
+    def _seed(self, runner, app, monkeypatch, tmp_path):
+        """Patch git root and store a few test entries; return (runner, app)."""
+        import cc.core.entry_store as es
+
+        monkeypatch.setattr(es, "_git_root", lambda: tmp_path)
+        runner.invoke(
+            app,
+            ["memory", "store", "--type", "decision", "Use WAL mode for SQLite"],
+        )
+        runner.invoke(
+            app,
+            ["memory", "store", "--type", "lesson", "--tags", "testing",
+             "Always write tests before shipping"],
+        )
+        runner.invoke(
+            app,
+            ["memory", "store", "--type", "context", "Monorepo layout chosen"],
+        )
+
+    def test_export_all_markdown_exits_zero(
+        self, cli_runner, cli_app, monkeypatch, tmp_path
+    ):
+        self._seed(cli_runner, cli_app, monkeypatch, tmp_path)
+        result = cli_runner.invoke(cli_app, ["memory", "export"])
+        assert result.exit_code == 0
+        assert "Memory Export" in result.output
+        assert "Entries: 3" in result.output
+
+    def test_export_all_contains_entry_content(
+        self, cli_runner, cli_app, monkeypatch, tmp_path
+    ):
+        self._seed(cli_runner, cli_app, monkeypatch, tmp_path)
+        result = cli_runner.invoke(cli_app, ["memory", "export"])
+        assert result.exit_code == 0
+        assert "WAL mode" in result.output
+        assert "Always write tests" in result.output
+        assert "Monorepo" in result.output
+
+    def test_export_type_filter(
+        self, cli_runner, cli_app, monkeypatch, tmp_path
+    ):
+        self._seed(cli_runner, cli_app, monkeypatch, tmp_path)
+        result = cli_runner.invoke(
+            cli_app, ["memory", "export", "--type", "decision"]
+        )
+        assert result.exit_code == 0
+        assert "WAL mode" in result.output
+        # Lesson and context entries must not appear
+        assert "Always write tests" not in result.output
+        assert "Monorepo" not in result.output
+
+    def test_export_json_output(
+        self, cli_runner, cli_app, monkeypatch, tmp_path
+    ):
+        self._seed(cli_runner, cli_app, monkeypatch, tmp_path)
+        result = cli_runner.invoke(cli_app, ["memory", "export", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 3
+
+    def test_export_json_round_trip(
+        self, cli_runner, cli_app, monkeypatch, tmp_path
+    ):
+        """Exported JSON entries must contain id, type, content, and tags."""
+        self._seed(cli_runner, cli_app, monkeypatch, tmp_path)
+        result = cli_runner.invoke(cli_app, ["memory", "export", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        types_found = {e["type"] for e in data}
+        assert types_found == {"decision", "lesson", "context"}
+        contents = {e["content"].strip() for e in data}
+        assert any("WAL mode" in c for c in contents)
+
+    def test_export_json_type_filter(
+        self, cli_runner, cli_app, monkeypatch, tmp_path
+    ):
+        self._seed(cli_runner, cli_app, monkeypatch, tmp_path)
+        result = cli_runner.invoke(
+            cli_app, ["memory", "export", "--json", "--type", "lesson"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert all(e["type"] == "lesson" for e in data)
+        assert len(data) == 1
+
+    def test_export_to_file(
+        self, cli_runner, cli_app, monkeypatch, tmp_path
+    ):
+        self._seed(cli_runner, cli_app, monkeypatch, tmp_path)
+        out_file = tmp_path / "export.md"
+        result = cli_runner.invoke(
+            cli_app, ["memory", "export", "--out", str(out_file)]
+        )
+        assert result.exit_code == 0
+        assert out_file.exists()
+        content = out_file.read_text(encoding="utf-8")
+        assert "Memory Export" in content
+        assert "WAL mode" in content
+
+    def test_export_json_to_file(
+        self, cli_runner, cli_app, monkeypatch, tmp_path
+    ):
+        self._seed(cli_runner, cli_app, monkeypatch, tmp_path)
+        out_file = tmp_path / "export.json"
+        result = cli_runner.invoke(
+            cli_app, ["memory", "export", "--json", "--out", str(out_file)]
+        )
+        assert result.exit_code == 0
+        assert out_file.exists()
+        data = json.loads(out_file.read_text(encoding="utf-8"))
+        assert isinstance(data, list)
+        assert len(data) == 3
+
+    def test_export_empty_store_markdown(
+        self, cli_runner, cli_app, monkeypatch, tmp_path
+    ):
+        import cc.core.entry_store as es
+
+        monkeypatch.setattr(es, "_git_root", lambda: tmp_path)
+        result = cli_runner.invoke(cli_app, ["memory", "export"])
+        assert result.exit_code == 0
+        assert "no entries" in result.output.lower()
+
+    def test_export_empty_store_json(
+        self, cli_runner, cli_app, monkeypatch, tmp_path
+    ):
+        import cc.core.entry_store as es
+
+        monkeypatch.setattr(es, "_git_root", lambda: tmp_path)
+        result = cli_runner.invoke(cli_app, ["memory", "export", "--json"])
+        assert result.exit_code == 0
+        assert json.loads(result.output) == []
+
+
+class TestMemoryExportApi:
+    """API-level tests for cc.api.memory_export."""
+
+    def test_api_export_returns_string(self, memory_root):
+        store_entry(entry_type="decision", content="API decision.", scope="project")
+        from cc.api import memory_export
+
+        output = memory_export(scope="project")
+        assert isinstance(output, str)
+        assert "API decision" in output
+
+    def test_api_export_json_format(self, memory_root):
+        store_entry(entry_type="lesson", content="API lesson.", scope="project")
+        from cc.api import memory_export
+
+        output = memory_export(scope="project", output_format="json")
+        data = json.loads(output)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert "API lesson" in data[0]["content"]
+
+    def test_api_export_type_filter(self, memory_root):
+        store_entry(entry_type="decision", content="keep this", scope="project")
+        store_entry(entry_type="lesson", content="exclude this", scope="project")
+        from cc.api import memory_export
+
+        output = memory_export(scope="project", entry_type="decision")
+        assert "keep this" in output
+        assert "exclude this" not in output
+
+    def test_api_export_invalid_format_raises(self, memory_root):
+        from cc.api import memory_export
+
+        with pytest.raises(ValueError, match="output_format"):
+            memory_export(scope="project", output_format="xml")

--- a/tools/tc/README.md
+++ b/tools/tc/README.md
@@ -148,7 +148,19 @@ tc wp store  --task <id> --type <type> --title "..." [--content "..."] [--file p
 tc wp get    <id>
 tc wp list   [--task <id>] [--type <type>]
 tc wp search "<query>"
+tc wp render <id> --html            # render to .copilot/renders/WP-<id>.html (token-free)
+tc wp render <id> --html --out /custom/path.html  # override output path
 ```
+
+**HTML rendering** produces a fully self-contained file (inline CSS, vanilla JS, no CDN) at `.copilot/renders/WP-<id>.html`. The CLI prints only the absolute path to stdout — the HTML body never enters the context window. Auto-detects one of three templates based on content:
+
+| Template | Trigger | Feature |
+|----------|---------|---------|
+| Severity | P0/P1/P2 or CRITICAL/HIGH/MEDIUM/LOW in content | Color-coded legend, severity-class CSS on rows |
+| Variant grid | ≥ 2 headings containing "option/variant/alternative/approach/solution" | Tabbed comparison layout |
+| Rendered diff | `\`\`\`diff` block or ≥ 3 `+x`/`-x` diff lines | Diff viewer with syntax highlighting |
+
+All rendered files include "Copy as Markdown" and "Copy as JSON" buttons. Long-form content (≥ 100 newlines) gets a Rendered / Source tab switcher.
 
 ### `tc stream`
 
@@ -223,6 +235,7 @@ tools/tc/
       tasks.py           # create_task, add_dependency
       prds.py            # create_prd
       wp.py              # store_wp
+      render_html.py     # render_wp_html — token-free HTML output (auto-detects template)
     db/
       connection.py      # get_db, init_db, find_db_path, transaction()
       schema.py          # CREATE TABLE statements

--- a/tools/tc/pyproject.toml
+++ b/tools/tc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "task-copilot-cli"
-version = "1.1.0"
+version = "1.2.0"
 description = "Agent-agnostic CLI for AI task management"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/tc/src/tc/__init__.py
+++ b/tools/tc/src/tc/__init__.py
@@ -1,6 +1,6 @@
 """Task Copilot CLI - Agent-agnostic task management."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 # Default paths
 DEFAULT_DB_DIR = ".copilot"

--- a/tools/tc/src/tc/api.py
+++ b/tools/tc/src/tc/api.py
@@ -87,6 +87,7 @@ from tc.services.wp import (
     search_wps,
     store_wp,
 )
+from tc.services.render_html import render_wp_html
 from tc.services.handoff import handoff_task
 from tc.services.log import list_log
 from tc.services.progress import get_progress
@@ -132,6 +133,7 @@ __all__ = [
     "get_wp",
     "list_wps",
     "search_wps",
+    "render_wp_html",
     # handoff
     "handoff_task",
     # log

--- a/tools/tc/src/tc/commands/wp.py
+++ b/tools/tc/src/tc/commands/wp.py
@@ -12,6 +12,42 @@ from tc.db.exceptions import TaskNotFound, ValidationError
 wp_app = typer.Typer(name="wp", help="Work product commands.")
 
 
+@wp_app.command("render")
+def wp_render(
+    wp_id: int = typer.Argument(..., help="Work product ID to render."),
+    html: bool = typer.Option(
+        True,
+        "--html/--no-html",
+        help="Render as self-contained HTML (default: true).",
+    ),
+    out: Optional[Path] = typer.Option(
+        None,
+        "--out",
+        help="Override the output file path (default: .copilot/renders/WP-<id>.html).",
+    ),
+) -> None:
+    """Render a work product to a standalone self-contained HTML file.
+
+    Prints only the absolute path to the rendered file — the HTML body is
+    never written to stdout (token-free side artifact).
+
+    Output path convention: .copilot/renders/WP-<id>.html
+    """
+    from tc.services.render_html import render_wp_html
+    from tc.db.exceptions import WorkProductNotFound
+
+    if not html:
+        error_exit("Only --html rendering is supported by this command.", EXIT_VALIDATION)
+
+    db_path = require_db()
+    try:
+        html_path = render_wp_html(wp_id=wp_id, out_path=out, db_path=db_path)
+    except WorkProductNotFound:
+        error_exit(f"Work product #{wp_id} not found.", EXIT_NOT_FOUND)
+
+    print(str(html_path))
+
+
 @wp_app.command("store")
 def wp_store(
     task: int = typer.Option(..., "--task", help="Associated task ID."),

--- a/tools/tc/src/tc/services/render_html.py
+++ b/tools/tc/src/tc/services/render_html.py
@@ -1,0 +1,632 @@
+"""tc.services.render_html — render a work product to a standalone HTML file.
+
+Output path convention:
+    <project-root>/.copilot/renders/WP-<id>.html
+
+Where ``.copilot/`` is the directory that holds ``tasks.db``.  The HTML file
+is completely self-contained: inline CSS only, vanilla JS only, no external
+assets, no CDN references.  The caller receives only the absolute file path
+so the rendered HTML never flows back into the main-session context window
+(TOKEN-FREE SIDE ARTIFACT).
+
+This module does NOT alter the work-product storage format and does NOT change
+what ``get_wp`` / ``list_wps`` return to callers.
+"""
+
+from __future__ import annotations
+
+import html as _html
+import json as _json
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any, Optional
+
+
+# ---------------------------------------------------------------------------
+# Template auto-detection
+# ---------------------------------------------------------------------------
+
+# Variant-grid: heading containing an "option/variant/alternative/approach/solution" keyword
+_VARIANT_HEADING_RE = re.compile(
+    r'^#{1,4}\s+.*\b(option|variant|alternative|approach|solution)\b',
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Rendered-diff: a fenced ```diff block, OR 3+ standalone diff lines (+x / -x, not +++ / ---)
+_DIFF_FENCE_RE = re.compile(r'```diff\s*\n(.*?)```', re.DOTALL | re.IGNORECASE)
+_DIFF_LINE_RE = re.compile(r'^[+-](?![+-])', re.MULTILINE)
+
+
+def _has_variant_grid(text: str) -> bool:
+    """True when the content has >= 2 variant/option headings."""
+    return len(_VARIANT_HEADING_RE.findall(text)) >= 2
+
+
+def _has_diff(text: str) -> bool:
+    """True when the content contains a ```diff block or >= 3 diff-formatted lines."""
+    if _DIFF_FENCE_RE.search(text):
+        return True
+    return len(_DIFF_LINE_RE.findall(text)) >= 3
+
+
+# ---------------------------------------------------------------------------
+# Severity detection
+# ---------------------------------------------------------------------------
+
+_SEV_RE = re.compile(r'\b(CRITICAL|HIGH|MEDIUM|MED|LOW|P0|P1|P2)\b')
+
+_SEV_CLASS: dict[str, str] = {
+    'CRITICAL': 'sev-critical',
+    'HIGH': 'sev-high',
+    'MEDIUM': 'sev-medium',
+    'MED': 'sev-medium',
+    'LOW': 'sev-low',
+    'P0': 'sev-p0',
+    'P1': 'sev-p1',
+    'P2': 'sev-p2',
+}
+
+
+def _sev_class(text: str) -> Optional[str]:
+    """Return the CSS severity class for the first marker in *text*, or None."""
+    m = _SEV_RE.search(text.upper())
+    return _SEV_CLASS.get(m.group(1)) if m else None
+
+
+def _has_severity(text: str) -> bool:
+    return bool(_SEV_RE.search(text.upper()))
+
+
+# ---------------------------------------------------------------------------
+# Inline markdown → HTML
+# ---------------------------------------------------------------------------
+
+_CODE_SPAN_RE = re.compile(r'`([^`]+)`')
+_BOLD_RE = re.compile(r'\*\*([^*\n]+)\*\*')
+_ITALIC_RE = re.compile(r'\*([^*\n]+)\*')
+_LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]*)\)')
+
+
+def _inline(raw: str) -> str:
+    """Convert raw inline markdown text to safe HTML.
+
+    Processing order:
+    1. Split on backtick code spans — code content is HTML-escaped only.
+    2. For each non-code segment: HTML-escape, then apply bold / italic / links.
+
+    This ordering ensures code span contents are never processed as markdown,
+    and HTML-special characters in regular text are escaped before the markdown
+    substitution patterns (which use only ``*`` and ``[]()`` — all safe after
+    ``html.escape``).
+    """
+    segments = _CODE_SPAN_RE.split(raw)
+    parts: list[str] = []
+    for i, seg in enumerate(segments):
+        if i % 2 == 1:
+            # Odd segments are the captured code span contents.
+            parts.append(f'<code>{_html.escape(seg)}</code>')
+        else:
+            s = _html.escape(seg)
+            s = _BOLD_RE.sub(r'<strong>\1</strong>', s)
+            s = _ITALIC_RE.sub(r'<em>\1</em>', s)
+            s = _LINK_RE.sub(r'<a href="\2">\1</a>', s)
+            parts.append(s)
+    return ''.join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Block-level markdown → HTML
+# ---------------------------------------------------------------------------
+
+_HEADING_RE = re.compile(r'^(#{1,6})\s+(.*)')
+_UL_RE = re.compile(r'^[-*+]\s')
+_OL_RE = re.compile(r'^\d+\.\s')
+_TABLE_RE = re.compile(r'^\|')
+_SEP_ROW_RE = re.compile(r'^[-:|]+$')
+
+
+def _is_block_start(line: str) -> bool:
+    """True when *line* opens a new structural block."""
+    s = line.lstrip()
+    return bool(
+        s.startswith('#')
+        or s.startswith('```')
+        or _TABLE_RE.match(s)
+        or _UL_RE.match(s)
+        or _OL_RE.match(s)
+    )
+
+
+def _render_table(rows: list[str]) -> str:
+    """Convert markdown table lines to an HTML ``<table>``."""
+    if not rows:
+        return ''
+    cells = [
+        [c.strip() for c in r.strip().strip('|').split('|')]
+        for r in rows
+    ]
+    header = cells[0]
+    body_start = 1
+    # Skip the separator row (e.g., ``|---|---|``)
+    if len(cells) > 1 and all(_SEP_ROW_RE.match(c.strip()) for c in cells[1] if c.strip()):
+        body_start = 2
+
+    thead = '<tr>' + ''.join(f'<th>{_inline(c)}</th>' for c in header) + '</tr>'
+    tbody_rows = [
+        '<tr>' + ''.join(f'<td>{_inline(c)}</td>' for c in row) + '</tr>'
+        for row in cells[body_start:]
+    ]
+    return (
+        '<table><thead>' + thead + '</thead>'
+        '<tbody>' + ''.join(tbody_rows) + '</tbody></table>'
+    )
+
+
+def _md_to_html(text: str) -> str:  # noqa: C901
+    """Convert a markdown string to an HTML fragment.
+
+    Handles: ATX headings, fenced code blocks, unordered/ordered lists,
+    tables, paragraphs, inline code, bold, italic, and links.
+    Severity markers (CRITICAL/HIGH/MED/LOW/P0/P1/P2) found in paragraphs
+    and list items are wrapped with the matching ``sev-*`` CSS class.
+    """
+    lines = text.split('\n')
+    out: list[str] = []
+    i = 0
+    n = len(lines)
+
+    while i < n:
+        line = lines[i]
+        stripped = line.strip()
+
+        # ── fenced code block ────────────────────────────────────────────────
+        if stripped.startswith('```'):
+            lang = stripped[3:].strip()
+            code_lines: list[str] = []
+            i += 1
+            while i < n and not lines[i].strip().startswith('```'):
+                code_lines.append(lines[i])
+                i += 1
+            i += 1  # consume closing ```
+            code_text = '\n'.join(code_lines)
+            lang_attr = (
+                f' class="language-{_html.escape(lang)}"' if lang else ''
+            )
+            out.append(
+                f'<pre><code{lang_attr}>{_html.escape(code_text)}</code></pre>'
+            )
+            continue
+
+        # ── ATX heading ──────────────────────────────────────────────────────
+        m = _HEADING_RE.match(line)
+        if m:
+            lvl = len(m.group(1))
+            out.append(f'<h{lvl}>{_inline(m.group(2))}</h{lvl}>')
+            i += 1
+            continue
+
+        # ── table ────────────────────────────────────────────────────────────
+        if '|' in stripped and _TABLE_RE.match(stripped):
+            tbl: list[str] = []
+            while i < n and '|' in lines[i] and _TABLE_RE.match(lines[i].strip()):
+                tbl.append(lines[i])
+                i += 1
+            out.append(_render_table(tbl))
+            continue
+
+        # ── unordered list ───────────────────────────────────────────────────
+        if _UL_RE.match(stripped):
+            items: list[str] = []
+            while i < n and _UL_RE.match(lines[i].strip()):
+                item_text = re.sub(r'^[-*+]\s+', '', lines[i].strip())
+                sev = _sev_class(item_text)
+                cls = f' class="{sev}"' if sev else ''
+                items.append(f'<li{cls}>{_inline(item_text)}</li>')
+                i += 1
+            out.append('<ul>' + ''.join(items) + '</ul>')
+            continue
+
+        # ── ordered list ─────────────────────────────────────────────────────
+        if _OL_RE.match(stripped):
+            items = []
+            while i < n and _OL_RE.match(lines[i].strip()):
+                item_text = re.sub(r'^\d+\.\s+', '', lines[i].strip())
+                sev = _sev_class(item_text)
+                cls = f' class="{sev}"' if sev else ''
+                items.append(f'<li{cls}>{_inline(item_text)}</li>')
+                i += 1
+            out.append('<ol>' + ''.join(items) + '</ol>')
+            continue
+
+        # ── blank line ───────────────────────────────────────────────────────
+        if not stripped:
+            i += 1
+            continue
+
+        # ── paragraph ────────────────────────────────────────────────────────
+        para_lines: list[str] = []
+        while i < n and lines[i].strip() and not _is_block_start(lines[i]):
+            para_lines.append(lines[i].strip())
+            i += 1
+        if para_lines:
+            para_text = ' '.join(para_lines)
+            sev = _sev_class(para_text)
+            p_html = f'<p>{_inline(para_text)}</p>'
+            if sev:
+                p_html = f'<div class="{sev}">{p_html}</div>'
+            out.append(p_html)
+        else:
+            i += 1  # safety skip to prevent infinite loop
+
+    return '\n'.join(out)
+
+
+# ---------------------------------------------------------------------------
+# Variant-grid rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_variant_grid(text: str) -> str:
+    """Split content at variant headings and render each section as a grid card.
+
+    Lines before the first variant heading are rendered as a preamble above
+    the grid.  If fewer than 2 variant headings are found, falls back to
+    standard markdown rendering.
+    """
+    lines = text.split('\n')
+    preamble: list[str] = []
+    sections: list[tuple[str, list[str]]] = []  # (heading_line, body_lines)
+    current_heading: str | None = None
+    current_body: list[str] = []
+
+    for line in lines:
+        if _VARIANT_HEADING_RE.match(line):
+            if current_heading is not None:
+                sections.append((current_heading, current_body))
+            elif current_body:
+                preamble = current_body[:]
+            current_heading = line
+            current_body = []
+        else:
+            current_body.append(line)
+
+    if current_heading is not None:
+        sections.append((current_heading, current_body))
+    elif not sections:
+        preamble = current_body
+
+    if len(sections) < 2:
+        return _md_to_html(text)
+
+    preamble_html = _md_to_html('\n'.join(preamble).strip()) if any(l.strip() for l in preamble) else ''
+
+    cards: list[str] = []
+    for heading, body_lines in sections:
+        heading_html = _md_to_html(heading)
+        body_html = _md_to_html('\n'.join(body_lines).strip()) if any(l.strip() for l in body_lines) else ''
+        cards.append(f'<div class="variant-card">{heading_html}{body_html}</div>')
+
+    grid_html = '<div class="variant-grid">' + '\n'.join(cards) + '</div>'
+    return (preamble_html + '\n' + grid_html) if preamble_html else grid_html
+
+
+# ---------------------------------------------------------------------------
+# Rendered-diff rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_diff_line(line: str) -> str:
+    """Wrap a single raw diff line with the appropriate CSS class span."""
+    escaped = _html.escape(line)
+    if line.startswith('@@'):
+        return f'<span class="diff-line diff-hunk">{escaped}</span>'
+    if line.startswith('+++') or line.startswith('---'):
+        return f'<span class="diff-line diff-file">{escaped}</span>'
+    if line.startswith('+'):
+        return f'<span class="diff-line diff-add">{escaped}</span>'
+    if line.startswith('-'):
+        return f'<span class="diff-line diff-remove">{escaped}</span>'
+    return f'<span class="diff-line">{escaped}</span>'
+
+
+def _render_diff_block(diff_text: str) -> str:
+    """Render a raw diff string as a color-coded HTML block."""
+    rendered = ''.join(_render_diff_line(l) for l in diff_text.split('\n'))
+    return f'<div class="diff-block">{rendered}</div>'
+
+
+def _render_diff_content(text: str) -> str:
+    """Replace fenced ```diff blocks with color-coded HTML; render remainder as markdown."""
+    parts: list[str] = []
+    last_end = 0
+    for m in _DIFF_FENCE_RE.finditer(text):
+        before = text[last_end:m.start()]
+        if before.strip():
+            parts.append(_md_to_html(before))
+        parts.append(_render_diff_block(m.group(1)))
+        last_end = m.end()
+    after = text[last_end:]
+    if after.strip():
+        parts.append(_md_to_html(after))
+    return '\n'.join(parts)
+
+
+# ---------------------------------------------------------------------------
+# HTML page template
+# ---------------------------------------------------------------------------
+
+_CSS = """\
+:root{--bg:#fff;--sf:#f8f9fa;--bd:#dee2e6;--tx:#212529;--mu:#6c757d;\
+--co:#f1f3f4;--lk:#0d6efd;--rc:#dc3545;--rh:#fd7e14;--rm:#ffc107;--rl:#198754}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;\
+font-size:15px;line-height:1.6;color:var(--tx);background:var(--bg);\
+padding:2rem;max-width:920px;margin:0 auto}
+header{margin-bottom:1.5rem;padding-bottom:1rem;border-bottom:2px solid var(--bd)}
+header h1{font-size:1.4rem;margin-bottom:.5rem}
+.meta{display:flex;flex-wrap:wrap;gap:1rem;font-size:.83rem;color:var(--mu);margin-bottom:.75rem}
+.actions{display:flex;gap:.5rem;flex-wrap:wrap}
+.btn{display:inline-flex;align-items:center;padding:.35rem .75rem;\
+font-size:.82rem;border:1px solid var(--bd);border-radius:6px;\
+background:var(--sf);color:var(--tx);cursor:pointer;transition:background .15s;\
+font-family:inherit}
+.btn:hover{background:var(--bd)}
+.tabs{display:flex;margin-bottom:1rem;border-bottom:1px solid var(--bd)}
+.tab-btn{padding:.5rem 1rem;font-size:.9rem;border:none;\
+border-bottom:2px solid transparent;background:none;color:var(--mu);\
+cursor:pointer;margin-bottom:-1px;font-family:inherit}
+.tab-btn.active{color:var(--tx);border-bottom-color:var(--lk);font-weight:500}
+.tab-pane{display:none}.tab-pane.active{display:block}
+.content h1,.content h2,.content h3,.content h4,.content h5,.content h6\
+{margin:1.2rem 0 .45rem;line-height:1.3}
+.content h1{font-size:1.6rem}
+.content h2{font-size:1.3rem;border-bottom:1px solid var(--bd);padding-bottom:.2rem}
+.content h3{font-size:1.1rem}
+.content p{margin:.6rem 0}
+.content ul,.content ol{margin:.6rem 0 .6rem 1.5rem}
+.content li{margin:.2rem 0}
+.content code{background:var(--co);padding:.1rem .35rem;border-radius:3px;\
+font-family:"SFMono-Regular",Consolas,monospace;font-size:.875em}
+.content pre{background:var(--sf);border:1px solid var(--bd);border-radius:6px;\
+padding:.85rem 1rem;overflow-x:auto;margin:.6rem 0}
+.content pre code{background:none;padding:0;font-size:.875rem}
+.content a{color:var(--lk);text-decoration:underline}
+.content strong{font-weight:600}
+.content table{width:100%;border-collapse:collapse;margin:.6rem 0;font-size:.9rem}
+.content th{background:var(--sf);font-weight:600;text-align:left}
+.content th,.content td{padding:.45rem .7rem;border:1px solid var(--bd)}
+.content tr:nth-child(even) td{background:var(--sf)}
+.sev-critical,.sev-p0{background:#fff5f5;border-left:4px solid var(--rc);\
+padding:.4rem .7rem;margin:.35rem 0;border-radius:0 4px 4px 0}
+.sev-high,.sev-p1{background:#fff8f0;border-left:4px solid var(--rh);\
+padding:.4rem .7rem;margin:.35rem 0;border-radius:0 4px 4px 0}
+.sev-medium,.sev-p2{background:#fffdf0;border-left:4px solid var(--rm);\
+padding:.4rem .7rem;margin:.35rem 0;border-radius:0 4px 4px 0}
+.sev-low{background:#f0fff4;border-left:4px solid var(--rl);\
+padding:.4rem .7rem;margin:.35rem 0;border-radius:0 4px 4px 0}
+.legend{display:flex;flex-wrap:wrap;align-items:center;gap:.75rem;\
+margin-bottom:1rem;padding:.55rem .75rem;background:var(--sf);\
+border-radius:6px;font-size:.8rem}
+.leg-item{display:flex;align-items:center;gap:.3rem}
+.leg-dot{width:9px;height:9px;border-radius:50%;display:inline-block}
+.dot-c{background:var(--rc)}.dot-h{background:var(--rh)}
+.dot-m{background:var(--rm)}.dot-l{background:var(--rl)}
+.src{font-family:"SFMono-Regular",Consolas,monospace;font-size:.875rem;\
+line-height:1.5;white-space:pre-wrap;word-break:break-word;padding:1rem;\
+background:var(--sf);border:1px solid var(--bd);border-radius:6px}
+.toast{position:fixed;bottom:1.5rem;right:1.5rem;background:#333;color:#fff;\
+padding:.55rem 1rem;border-radius:6px;font-size:.875rem;opacity:0;\
+transition:opacity .2s;pointer-events:none;z-index:9999}
+.toast.show{opacity:1}
+.variant-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));\
+gap:1.25rem;margin:1rem 0}
+.variant-card{border:1px solid var(--bd);border-radius:8px;padding:1rem;\
+background:var(--sf)}
+.variant-card h1,.variant-card h2,.variant-card h3,.variant-card h4\
+{margin-top:0;padding-bottom:.35rem;border-bottom:2px solid var(--lk);\
+color:var(--lk);font-size:1rem}
+.diff-block{font-family:"SFMono-Regular",Consolas,monospace;font-size:.875rem;\
+border:1px solid var(--bd);border-radius:6px;overflow-x:auto;margin:.6rem 0;\
+background:#fafafa;line-height:1.4}
+.diff-line{padding:.05rem .5rem;display:block;white-space:pre}
+.diff-add{background:#e6ffed;color:#22863a}
+.diff-remove{background:#ffeef0;color:#b31d28}
+.diff-hunk{background:#dbedff;color:#005cc5;font-weight:600}
+.diff-file{color:var(--mu);font-weight:600}\
+"""
+
+
+def _js_str(value: str) -> str:
+    """JSON-encode *value* for safe embedding inside a ``<script>`` block."""
+    # Replace '</' to prevent premature ``</script>`` tag closure.
+    return _json.dumps(value, ensure_ascii=False).replace('</', '<\\/')
+
+
+def _build_html_page(wp: dict[str, Any], content: str) -> str:
+    """Assemble the complete standalone HTML document for *wp*."""
+    wp_id = wp.get('id', '?')
+    title = wp.get('title') or 'Untitled'
+    wp_type = wp.get('type') or ''
+    task_id = wp.get('task_id', '')
+    agent = wp.get('agent') or ''
+    created_at = str(wp.get('created_at') or '')
+
+    title_e = _html.escape(title)
+    type_e = _html.escape(wp_type)
+    agent_span = (
+        f'<span><strong>Agent:</strong> {_html.escape(agent)}</span>'
+        if agent else ''
+    )
+
+    use_tabs = content.count('\n') >= 100
+    show_legend = _has_severity(content)
+
+    # Auto-select template: diff > variant-grid > standard
+    if _has_diff(content):
+        rendered_body = _render_diff_content(content)
+    elif _has_variant_grid(content):
+        rendered_body = _render_variant_grid(content)
+    else:
+        rendered_body = _md_to_html(content)
+
+    legend_html = ''
+    if show_legend:
+        legend_html = (
+            '<div class="legend"><strong>Severity:</strong>'
+            '<span class="leg-item"><span class="leg-dot dot-c"></span>CRITICAL / P0</span>'
+            '<span class="leg-item"><span class="leg-dot dot-h"></span>HIGH / P1</span>'
+            '<span class="leg-item"><span class="leg-dot dot-m"></span>MEDIUM / P2</span>'
+            '<span class="leg-item"><span class="leg-dot dot-l"></span>LOW</span>'
+            '</div>'
+        )
+
+    if use_tabs:
+        tabs_nav = (
+            '<nav class="tabs">'
+            '<button class="tab-btn active" data-tab="rendered" '
+            'onclick="showTab(\'rendered\')">Rendered</button>'
+            '<button class="tab-btn" data-tab="source" '
+            'onclick="showTab(\'source\')">Source</button>'
+            '</nav>'
+        )
+        main_html = (
+            tabs_nav
+            + f'<div id="tab-rendered" class="tab-pane active">'
+            + legend_html
+            + f'<div class="content">{rendered_body}</div></div>'
+            + f'<div id="tab-source" class="tab-pane">'
+            + f'<pre class="src">{_html.escape(content)}</pre></div>'
+        )
+        tab_js = (
+            'function showTab(n){'
+            'document.querySelectorAll(".tab-btn")'
+            '.forEach(b=>b.classList.toggle("active",b.dataset.tab===n));'
+            'document.querySelectorAll(".tab-pane")'
+            '.forEach(p=>p.classList.toggle("active",p.id==="tab-"+n));'
+            '}'
+        )
+    else:
+        main_html = (
+            legend_html
+            + f'<div class="content">{rendered_body}</div>'
+        )
+        tab_js = ''
+
+    # Build JSON payload for "Copy as JSON" button (include resolved content).
+    wp_copy = dict(wp)
+    wp_copy['content'] = content
+    wp_json_str = _json.dumps(wp_copy, indent=2, default=str)
+
+    md_js = _js_str(content)
+    json_js = _js_str(wp_json_str)
+
+    script = f"""\
+const MD={md_js};
+const WPJSON={json_js};
+function toast(m){{const t=document.getElementById('toast');t.textContent=m;\
+t.classList.add('show');setTimeout(()=>t.classList.remove('show'),1800);}}
+function copyMd(){{if(!navigator.clipboard){{toast('Clipboard unavailable');return;}}\
+navigator.clipboard.writeText(MD).then(()=>toast('Copied as Markdown ✓'))\
+.catch(()=>toast('Copy failed — check permissions'));}}
+function copyJson(){{if(!navigator.clipboard){{toast('Clipboard unavailable');return;}}\
+navigator.clipboard.writeText(WPJSON).then(()=>toast('Copied as JSON ✓'))\
+.catch(()=>toast('Copy failed — check permissions'));}}
+{tab_js}"""
+
+    return (
+        '<!DOCTYPE html>\n'
+        '<html lang="en">\n'
+        '<head>\n'
+        '<meta charset="UTF-8">\n'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">\n'
+        f'<title>WP-{wp_id}: {title_e}</title>\n'
+        f'<style>{_CSS}</style>\n'
+        '</head>\n'
+        '<body>\n'
+        '<header>\n'
+        f'<h1>WP-{wp_id}: {title_e}</h1>\n'
+        '<div class="meta">'
+        f'<span><strong>Type:</strong> {type_e}</span>'
+        f'<span><strong>Task:</strong> #{task_id}</span>'
+        f'{agent_span}'
+        f'<span><strong>Created:</strong> {_html.escape(created_at)}</span>'
+        '</div>\n'
+        '<div class="actions">'
+        '<button class="btn" onclick="copyMd()">Copy as Markdown</button>'
+        '<button class="btn" onclick="copyJson()">Copy as JSON</button>'
+        '</div>\n'
+        '</header>\n'
+        + main_html + '\n'
+        '<div class="toast" id="toast"></div>\n'
+        f'<script>{script}</script>\n'
+        '</body>\n'
+        '</html>'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def render_wp_html(
+    *,
+    wp_id: int,
+    out_path: Optional[Path] = None,
+    conn: Optional[sqlite3.Connection] = None,
+    db_path: Optional[Path] = None,
+) -> Path:
+    """Render work product *wp_id* to a self-contained HTML file on disk.
+
+    This is a TOKEN-FREE SIDE ARTIFACT: the HTML is written to disk and the
+    caller receives only the absolute ``Path``.  It does NOT alter stored
+    work products or change what ``get_wp`` / ``list_wps`` return.
+
+    Output path convention (when *out_path* is omitted):
+        ``<db_parent>/renders/WP-<id>.html``
+    where ``<db_parent>`` is the ``.copilot/`` directory that holds
+    ``tasks.db``.  Example: ``.copilot/renders/WP-42.html``.
+
+    Args:
+        wp_id:    Work product ID to render.
+        out_path: Override the output file path.
+        conn:     Existing DB connection (not opened/closed by this function).
+        db_path:  Explicit DB path; walked up from ``cwd`` if ``None``.
+
+    Returns:
+        Absolute ``Path`` to the written HTML file.
+
+    Raises:
+        WorkProductNotFound: if *wp_id* does not exist.
+        FileNotFoundError:   if no DB is found and *db_path* is None.
+    """
+    from tc.services.wp import get_wp
+
+    # Resolve DB path (needed for the renders directory and for get_wp).
+    resolved_db: Optional[Path]
+    if db_path is not None:
+        resolved_db = db_path
+    else:
+        from tc.db.connection import find_db_path
+        resolved_db = find_db_path()
+
+    # Fetch the work product (raises WorkProductNotFound if missing).
+    wp = get_wp(wp_id=wp_id, db_path=resolved_db)
+    content: str = wp.get('content') or ''
+
+    # Determine the output file path.
+    if out_path is not None:
+        html_path = Path(out_path)
+    elif resolved_db is not None:
+        renders_dir = resolved_db.parent / 'renders'
+        renders_dir.mkdir(parents=True, exist_ok=True)
+        html_path = renders_dir / f'WP-{wp_id}.html'
+    else:
+        html_path = Path.cwd() / f'WP-{wp_id}.html'
+
+    html_path.parent.mkdir(parents=True, exist_ok=True)
+
+    page = _build_html_page(wp, content)
+    html_path.write_text(page, encoding='utf-8')
+
+    return html_path.resolve()

--- a/tools/tc/tests/test_wp_render.py
+++ b/tools/tc/tests/test_wp_render.py
@@ -1,0 +1,864 @@
+"""Tests for tc wp render — HTML work-product renderer.
+
+Verifies:
+- render produces a file at the expected path
+- rendered HTML is self-contained (no external http/https asset references)
+- copy-as buttons are present (Copy as Markdown, Copy as JSON)
+- severity markers are color-coded via CSS classes
+- severity legend appears when markers found, absent when not
+- tc wp get output is unchanged after rendering (no storage side-effects)
+- --out path override works
+- stdout contains only the file path (token-free contract)
+- non-existent WP exits with EXIT_NOT_FOUND
+- tabbed nav present for long content (>= 100 lines), absent for short content
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _setup_task(cli):
+    result = cli(["task", "create", "--title", "Render Test Task", "--json"])
+    return json.loads(result.output)["id"]
+
+
+def _store_wp(cli, task_id, content, title="Test WP", type_="analysis"):
+    result = cli([
+        "wp", "store",
+        "--task", str(task_id),
+        "--type", type_,
+        "--title", title,
+        "--content", content,
+        "--json",
+    ])
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)
+
+
+# ---------------------------------------------------------------------------
+# render produces a file
+# ---------------------------------------------------------------------------
+
+class TestWpRenderProducesFile:
+    def test_render_creates_html_file(self, cli, db_path):
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "# Hello\n\nSome content here.")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0, result.output
+
+        html_path = Path(result.output.strip())
+        assert html_path.exists(), f"Expected HTML file at {html_path}"
+        assert html_path.suffix == ".html"
+        assert "WP-1" in html_path.name
+
+    def test_render_default_path_convention(self, cli, db_path):
+        """Output path must be <db_parent>/renders/WP-<id>.html."""
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "Content.")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_path = Path(result.output.strip())
+        # db_path is <tmp>/.copilot/tasks.db
+        # renders must be at <tmp>/.copilot/renders/WP-1.html
+        expected = db_path.parent / "renders" / "WP-1.html"
+        assert html_path.resolve() == expected.resolve()
+
+    def test_render_out_path_override(self, cli, db_path, tmp_dir):
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "Content.")
+
+        custom_out = tmp_dir / "custom_output.html"
+        result = cli(["wp", "render", "1", "--html", "--out", str(custom_out)])
+        assert result.exit_code == 0
+
+        html_path = Path(result.output.strip())
+        assert html_path.resolve() == custom_out.resolve()
+        assert custom_out.exists()
+
+    def test_render_stdout_is_path_only(self, cli, db_path):
+        """stdout MUST contain only the file path — never the HTML body."""
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "# Doc\n\nSome text.")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        output = result.output.strip()
+        # Must be a single line
+        assert '\n' not in output
+        # Must not contain HTML tags
+        assert '<html' not in output
+        assert '<body' not in output
+        # Must be an absolute path to an existing file
+        html_path = Path(output)
+        assert html_path.is_absolute()
+        assert html_path.exists()
+
+    def test_render_nonexistent_wp(self, cli):
+        result = cli(["wp", "render", "999", "--html"])
+        assert result.exit_code == 2  # EXIT_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# Self-contained — no external asset references
+# ---------------------------------------------------------------------------
+
+class TestWpRenderSelfContained:
+    def test_no_external_http_references(self, cli, db_path):
+        """The rendered HTML must not reference any http:// or https:// assets."""
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "# Title\n\nParagraph with [a link](https://example.com).")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+
+        # Extract all src/href/url() references (not link text)
+        # Links in <a href="..."> are allowed (they're content links, not asset loads)
+        # Disallow: <link href>, <script src>, <img src>, @import url(), etc.
+        external_asset_patterns = [
+            r'<link\b[^>]*\bhref=["\']https?://',
+            r'<script\b[^>]*\bsrc=["\']https?://',
+            r'<img\b[^>]*\bsrc=["\']https?://',
+            r'url\(["\']?https?://',
+            r'@import\s+["\']https?://',
+        ]
+        for pattern in external_asset_patterns:
+            matches = re.findall(pattern, html_content, re.IGNORECASE)
+            assert not matches, f"Found external asset reference matching {pattern!r}: {matches}"
+
+    def test_no_cdn_references(self, cli, db_path):
+        """No well-known CDN hostnames should appear as asset sources."""
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "Content.")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        cdn_patterns = [
+            'cdn.jsdelivr.net',
+            'cdnjs.cloudflare.com',
+            'unpkg.com',
+            'fonts.googleapis.com',
+            'fonts.gstatic.com',
+            'stackpath.bootstrapcdn.com',
+        ]
+        for cdn in cdn_patterns:
+            assert cdn not in html_content, f"Found CDN reference: {cdn}"
+
+    def test_valid_html_structure(self, cli, db_path):
+        """Rendered file must open with DOCTYPE and contain key structural tags."""
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "Simple content.")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert html_content.startswith("<!DOCTYPE html>")
+        assert "<html" in html_content
+        assert "<head>" in html_content or "<head\n" in html_content
+        assert "<body>" in html_content or "<body\n" in html_content
+        assert "<style>" in html_content  # inline CSS present
+        assert "</html>" in html_content
+
+
+# ---------------------------------------------------------------------------
+# Copy-as buttons
+# ---------------------------------------------------------------------------
+
+class TestWpRenderCopyButtons:
+    def test_copy_markdown_button_present(self, cli, db_path):
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "# My WP\n\nContent.")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert "Copy as Markdown" in html_content
+
+    def test_copy_json_button_present(self, cli, db_path):
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "Content.")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert "Copy as JSON" in html_content
+
+    def test_clipboard_api_used(self, cli, db_path):
+        """The JS must use navigator.clipboard for the copy actions."""
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "Content.")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert "navigator.clipboard" in html_content
+
+    def test_markdown_source_embedded(self, cli, db_path):
+        """The original markdown source must be embedded in the JS for copying."""
+        task_id = _setup_task(cli)
+        content = "# Source\n\nDistinct markdown text for test_markdown_source_embedded."
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        # The source is JSON-encoded in the script block
+        assert "test_markdown_source_embedded" in html_content
+
+    def test_json_payload_embedded(self, cli, db_path):
+        """The WP JSON record must be embedded in the JS for copying."""
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "Content.", title="UniqueJsonTitle999")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert "UniqueJsonTitle999" in html_content
+
+
+# ---------------------------------------------------------------------------
+# Severity color-coding
+# ---------------------------------------------------------------------------
+
+class TestWpRenderSeverityColoring:
+    def test_critical_marker_gets_css_class(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "# Security Review\n\n**CRITICAL**: Buffer overflow in parser.\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'sev-critical' in html_content
+
+    def test_high_marker_gets_css_class(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "- HIGH: SQL injection risk in query builder.\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'sev-high' in html_content
+
+    def test_medium_marker_gets_css_class(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "MEDIUM priority: missing rate limiting.\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'sev-medium' in html_content
+
+    def test_low_marker_gets_css_class(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "LOW: verbose logging in production.\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'sev-low' in html_content
+
+    def test_p0_marker_gets_css_class(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "P0: System crash on empty input.\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'sev-p0' in html_content
+
+    def test_p1_marker_gets_css_class(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "- P1: Auth bypass via header manipulation.\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'sev-p1' in html_content
+
+    def test_p2_marker_gets_css_class(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "P2 issue: inefficient loop detected.\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'sev-p2' in html_content
+
+    def test_severity_legend_shown_when_markers_present(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "CRITICAL: major issue.\nHIGH: another issue.\nLOW: minor note.\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'class="legend"' in html_content
+
+    def test_severity_legend_absent_for_plain_prose(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "# Implementation Notes\n\nThis module handles authentication.\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'class="legend"' not in html_content
+
+    def test_mixed_severity_all_classes_present(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = (
+            "# Code Review\n\n"
+            "P0: Auth token not invalidated on logout.\n\n"
+            "HIGH risk: plain-text secrets in config.\n\n"
+            "MED: missing input sanitization.\n\n"
+            "LOW: log message spelling error.\n"
+        )
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'sev-p0' in html_content
+        assert 'sev-high' in html_content
+        assert 'sev-medium' in html_content
+        assert 'sev-low' in html_content
+
+
+# ---------------------------------------------------------------------------
+# wp get unchanged after render (no storage side-effects)
+# ---------------------------------------------------------------------------
+
+class TestWpGetUnchangedAfterRender:
+    def test_wp_get_json_unchanged(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "# Original\n\nContent that must not be altered."
+        _store_wp(cli, task_id, content)
+
+        # Capture wp get output before render
+        before = cli(["wp", "get", "1", "--json"])
+        assert before.exit_code == 0
+        before_data = json.loads(before.output)
+
+        # Render
+        render_result = cli(["wp", "render", "1", "--html"])
+        assert render_result.exit_code == 0
+
+        # Capture wp get output after render
+        after = cli(["wp", "get", "1", "--json"])
+        assert after.exit_code == 0
+        after_data = json.loads(after.output)
+
+        # The stored record must be byte-for-byte identical
+        assert before_data == after_data
+
+    def test_wp_list_unchanged_after_render(self, cli, db_path):
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "Content A.")
+        _store_wp(cli, task_id, "Content B.")
+
+        before_list = json.loads(cli(["wp", "list", "--json"]).output)
+
+        cli(["wp", "render", "1", "--html"])
+        cli(["wp", "render", "2", "--html"])
+
+        after_list = json.loads(cli(["wp", "list", "--json"]).output)
+
+        assert len(before_list) == len(after_list)
+        assert before_list == after_list
+
+    def test_render_does_not_create_new_wp_record(self, cli, db_path):
+        """Rendering must not add rows to work_products table."""
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "Content.")
+
+        before_count = len(json.loads(cli(["wp", "list", "--json"]).output))
+
+        cli(["wp", "render", "1", "--html"])
+
+        after_count = len(json.loads(cli(["wp", "list", "--json"]).output))
+        assert before_count == after_count
+
+
+# ---------------------------------------------------------------------------
+# Tabbed navigation for long content
+# ---------------------------------------------------------------------------
+
+class TestWpRenderTabs:
+    def test_tabs_present_for_long_content(self, cli, db_path):
+        """Content with >= 100 newlines must render with tabbed nav."""
+        task_id = _setup_task(cli)
+        # Generate content with exactly 100 lines
+        content = "\n".join(f"Line {i}" for i in range(101))
+        assert content.count('\n') >= 100
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'class="tabs"' in html_content
+        assert "Rendered" in html_content
+        assert "Source" in html_content
+
+    def test_tabs_absent_for_short_content(self, cli, db_path):
+        """Short content (< 100 lines) must NOT have tabbed nav."""
+        task_id = _setup_task(cli)
+        content = "# Short\n\nJust a few lines.\n"
+        assert content.count('\n') < 100
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'class="tabs"' not in html_content
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering accuracy
+# ---------------------------------------------------------------------------
+
+class TestWpRenderMarkdown:
+    def test_headings_rendered(self, cli, db_path):
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "# H1\n## H2\n### H3\n")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert '<h1>' in html_content
+        assert '<h2>' in html_content
+        assert '<h3>' in html_content
+
+    def test_code_block_rendered(self, cli, db_path):
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "```python\nprint('hello')\n```\n")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert '<pre>' in html_content
+        assert '<code' in html_content
+
+    def test_html_injection_escaped(self, cli, db_path):
+        """Content with HTML-special chars must be escaped, not injected."""
+        task_id = _setup_task(cli)
+        dangerous = '<script>alert("xss")</script>'
+        _store_wp(cli, task_id, dangerous)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        # The raw script tag must NOT appear outside the JS data blocks
+        # The content div must contain the escaped form
+        assert '&lt;script&gt;' in html_content or 'alert' not in html_content.split('<script>')[0]
+
+    def test_table_rendered(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "| Col A | Col B |\n|---|---|\n| Val 1 | Val 2 |\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert '<table>' in html_content
+        assert '<th>' in html_content
+        assert 'Val 1' in html_content
+
+    def test_bold_italic_rendered(self, cli, db_path):
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "**bold text** and *italic text*")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert '<strong>' in html_content
+        assert '<em>' in html_content
+
+    def test_unordered_list_rendered(self, cli, db_path):
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "- item one\n- item two\n- item three\n")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert '<ul>' in html_content
+        assert '<li>' in html_content
+
+    def test_ordered_list_rendered(self, cli, db_path):
+        task_id = _setup_task(cli)
+        _store_wp(cli, task_id, "1. first\n2. second\n3. third\n")
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html_content = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert '<ol>' in html_content
+        assert '<li>' in html_content
+
+
+# ---------------------------------------------------------------------------
+# API-level tests (render_wp_html function directly)
+# ---------------------------------------------------------------------------
+
+class TestRenderWpHtmlApi:
+    def test_api_returns_absolute_path(self, db_path):
+        from tc.services.render_html import render_wp_html
+        from tc.services.wp import store_wp, get_wp
+        from tc.db.connection import get_db
+
+        conn = get_db(db_path)
+        # Create task manually
+        conn.execute(
+            "INSERT INTO tasks (title, status, priority) VALUES (?, 'pending', 0)",
+            ("API Test Task",)
+        )
+        conn.commit()
+
+        store_wp(task_id=1, type_="note", title="API WP", content="Hello world.", db_path=db_path)
+
+        html_path = render_wp_html(wp_id=1, db_path=db_path)
+        conn.close()
+
+        assert html_path.is_absolute()
+        assert html_path.exists()
+
+    def test_api_wp_not_found_raises(self, db_path):
+        from tc.services.render_html import render_wp_html
+        from tc.db.exceptions import WorkProductNotFound
+
+        with pytest.raises(WorkProductNotFound):
+            render_wp_html(wp_id=9999, db_path=db_path)
+
+    def test_api_custom_out_path(self, db_path, tmp_path):
+        from tc.services.render_html import render_wp_html
+        from tc.services.wp import store_wp
+        from tc.db.connection import get_db
+
+        conn = get_db(db_path)
+        conn.execute(
+            "INSERT INTO tasks (title, status, priority) VALUES (?, 'pending', 0)",
+            ("API Task",)
+        )
+        conn.commit()
+        store_wp(task_id=1, type_="note", title="WP", content="Content.", db_path=db_path)
+        conn.close()
+
+        custom = tmp_path / "custom.html"
+        result_path = render_wp_html(wp_id=1, out_path=custom, db_path=db_path)
+
+        assert result_path.resolve() == custom.resolve()
+        assert custom.exists()
+
+
+# ---------------------------------------------------------------------------
+# Variant-grid template
+# ---------------------------------------------------------------------------
+
+class TestVariantGridTemplate:
+    """variant-grid template: >= 2 option/variant/approach headings → CSS grid."""
+
+    def test_variant_grid_renders_grid_class(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = (
+            "# Comparison\n\n"
+            "Intro paragraph.\n\n"
+            "## Option A: Redis Cache\n\nFast, requires separate service.\n\n"
+            "## Option B: In-Memory Cache\n\nSimple, not persistent.\n"
+        )
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'class="variant-grid"' in html
+
+    def test_variant_grid_each_option_is_a_card(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = (
+            "## Option A: Approach Alpha\n\nDetails for alpha.\n\n"
+            "## Option B: Approach Beta\n\nDetails for beta.\n"
+        )
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert html.count('class="variant-card"') == 2
+
+    def test_variant_grid_three_variants(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = (
+            "## Variant 1: Alpha\n\nContent A.\n\n"
+            "## Variant 2: Beta\n\nContent B.\n\n"
+            "## Variant 3: Gamma\n\nContent C.\n"
+        )
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert html.count('class="variant-card"') == 3
+        assert "Content A" in html
+        assert "Content B" in html
+        assert "Content C" in html
+
+    def test_variant_grid_preamble_rendered(self, cli, db_path):
+        """Text before the first variant heading must appear above the grid."""
+        task_id = _setup_task(cli)
+        content = (
+            "# Design Decision\n\n"
+            "Preamble text that describes the decision context.\n\n"
+            "## Option A: First approach\n\nBody A.\n\n"
+            "## Option B: Second approach\n\nBody B.\n"
+        )
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert "Preamble text" in html
+        assert 'class="variant-grid"' in html
+
+    def test_single_option_falls_back_to_standard(self, cli, db_path):
+        """Only 1 variant heading — must NOT produce a grid (fallback to standard)."""
+        task_id = _setup_task(cli)
+        content = "## Option A: The only option\n\nJust one.\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'class="variant-grid"' not in html
+
+    def test_variant_grid_self_contained_no_external_assets(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = (
+            "## Alternative X\n\nX details.\n\n"
+            "## Alternative Y\n\nY details.\n"
+        )
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        for pattern in [
+            r'<link\b[^>]*\bhref=["\']https?://',
+            r'<script\b[^>]*\bsrc=["\']https?://',
+        ]:
+            assert not re.findall(pattern, html, re.IGNORECASE)
+
+    def test_approach_keyword_triggers_grid(self, cli, db_path):
+        """The 'approach' keyword in headings must also trigger the grid."""
+        task_id = _setup_task(cli)
+        content = (
+            "## Approach 1: Incremental\n\nGradual rollout.\n\n"
+            "## Approach 2: Big-bang\n\nFull cutover.\n"
+        )
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'class="variant-grid"' in html
+
+
+# ---------------------------------------------------------------------------
+# Rendered-diff template
+# ---------------------------------------------------------------------------
+
+class TestRenderedDiffTemplate:
+    """rendered-diff template: fenced ```diff blocks → color-coded HTML."""
+
+    def test_diff_block_renders_diff_block_class(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = (
+            "# Code Review\n\n"
+            "```diff\n"
+            "-old line\n"
+            "+new line\n"
+            "```\n"
+        )
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'class="diff-block"' in html
+
+    def test_diff_added_lines_get_diff_add_class(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "```diff\n+added line here\n context\n-removed line\n```\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'diff-add' in html
+
+    def test_diff_removed_lines_get_diff_remove_class(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "```diff\n+added line\n context\n-removed line here\n```\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'diff-remove' in html
+
+    def test_diff_hunk_header_gets_diff_hunk_class(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = (
+            "```diff\n"
+            "@@ -1,4 +1,4 @@\n"
+            " context\n"
+            "-old\n"
+            "+new\n"
+            "```\n"
+        )
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'diff-hunk' in html
+
+    def test_diff_file_headers_get_diff_file_class(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = (
+            "```diff\n"
+            "--- a/file.py\n"
+            "+++ b/file.py\n"
+            "@@ -1 +1 @@\n"
+            "-old\n"
+            "+new\n"
+            "```\n"
+        )
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'diff-file' in html
+
+    def test_diff_surrounding_markdown_rendered(self, cli, db_path):
+        """Non-diff content before/after a diff block must render as HTML."""
+        task_id = _setup_task(cli)
+        content = (
+            "# Change Summary\n\n"
+            "This patch fixes the bug.\n\n"
+            "```diff\n"
+            "-old\n"
+            "+new\n"
+            "```\n\n"
+            "Review complete.\n"
+        )
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert "<h1>" in html
+        assert "This patch fixes the bug" in html
+        assert "Review complete" in html
+        assert 'class="diff-block"' in html
+
+    def test_diff_self_contained_no_external_assets(self, cli, db_path):
+        task_id = _setup_task(cli)
+        content = "```diff\n-old\n+new\n```\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        for pattern in [
+            r'<link\b[^>]*\bhref=["\']https?://',
+            r'<script\b[^>]*\bsrc=["\']https?://',
+        ]:
+            assert not re.findall(pattern, html, re.IGNORECASE)
+
+    def test_plain_content_no_diff_class(self, cli, db_path):
+        """Standard prose must NOT produce diff-block markup."""
+        task_id = _setup_task(cli)
+        content = "# Normal Content\n\nJust prose here.\n"
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        assert 'class="diff-block"' not in html
+
+    def test_diff_takes_priority_over_variant_grid(self, cli, db_path):
+        """When both diff and variant keywords are present, diff wins."""
+        task_id = _setup_task(cli)
+        content = (
+            "## Option A: Old Approach\n\n"
+            "```diff\n-old\n+new\n```\n\n"
+            "## Option B: New Approach\n\nNew stuff.\n"
+        )
+        _store_wp(cli, task_id, content)
+
+        result = cli(["wp", "render", "1", "--html"])
+        assert result.exit_code == 0
+
+        html = Path(result.output.strip()).read_text(encoding="utf-8")
+        # diff template wins (diff-block present, variant-grid absent)
+        assert 'class="diff-block"' in html


### PR DESCRIPTION
## Summary

- **HTML work-product renderer** (`tc wp render <id> --html`): fully self-contained HTML side artifact at `.copilot/renders/WP-<id>.html` — auto-detects three templates (severity, variant-grid, rendered-diff), includes "Copy as Markdown" and "Copy as JSON" buttons. Zero new PyPI dependencies. ADR-004 records the decision.
- **Safety primitives `/careful` + `/freeze`**: `pretool-check.sh` rule functions backed by runtime-reloadable `security-rules.json`. Blocks/warns destructive Bash patterns; freeze locks Edit/Write/Bash to a declared path scope. Escape hatches: `COPILOT_CAREFUL=off`, `COPILOT_FREEZE=off`, `COPILOT_SAFETY=off`.
- **Availability-gated adversarial QA pass** (`adversarial-pass.sh`): new `adversarial-run` ARTIFACT type recognized by `subagent-stop.sh`; degrades cleanly when no external model CLI is present (`codex`, `llm`, `mods`).
- **`<promise>CONFUSED</promise>` loop-state**: added to `me`, `ta`, `do`, `sec`, `qa` agents — surfaces genuine decision forks to user instead of activating the QA gate.
- **`cc memory export`**: export memory entries to Markdown or JSON bundle with keyword, type, and `--all` filters.
- **Version bumps**: framework `5.11.0`, `cc` `1.5.0`, `tc` `1.2.0`.
- 9 accumulated session work-log memory entries committed (PRD-7/PRD-8).

## Attribution

- **gstack** by Garry Tan (`github.com/garrytan/gstack`, MIT) — inspiration for `/careful`+`/freeze` safety primitives, cross-model adversarial review, HTML side-artifact pattern, and the Confusion Protocol. Concepts adopted natively; no code copied.
- **"The Unreasonable Effectiveness of HTML"** by Thariq Shihipar (Anthropic Engineering Blog) — inspiration for HTML-as-output-format with "Copy as Markdown/JSON" buttons and variant-grid comparison layouts. Concepts adopted natively; no code copied.

## QA Evidence

QA-APPROVED: WP-163 — **1,033 tests pass**, version integrity confirmed across all components. Adversarial-pass availability-gated (no external model CLI required). PRD-8 / WP-151.

## Test plan

- [ ] CI / CodeQL passes (required by branch protection)
- [ ] `tc wp render <id> --html` produces `.copilot/renders/WP-<id>.html` with correct template detection
- [ ] `COPILOT_SAFETY=off git push` bypasses `/careful` rule (escape hatch works)
- [ ] `cc memory export --json` outputs valid JSON array
- [ ] Adversarial pass degrades gracefully when no `codex`/`llm`/`mods` in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)