### PR TITLE
chore: persist session memory + work products

### DIFF
--- a/.claude/memory/entries/01fbe74a-0bd8-4ffd-a8c7-d94a37afd77a.md
+++ b/.claude/memory/entries/01fbe74a-0bd8-4ffd-a8c7-d94a37afd77a.md
@@ -1,0 +1,10 @@
+---
+id: 01fbe74a-0bd8-4ffd-a8c7-d94a37afd77a
+type: reference
+tags: [3f6d0af, eval, qa]
+created: 2026-06-29T18:44:42Z
+updated: 2026-06-29T18:44:42Z
+scope: project
+---
+
+eval qa pass_rate=1.0000 passed=10/10 p0_regression=False sha=3f6d0af date=2026-06-29

--- a/.claude/memory/entries/d461e173-e5b5-4059-9dea-6232e6bafd07.md
+++ b/.claude/memory/entries/d461e173-e5b5-4059-9dea-6232e6bafd07.md
@@ -1,0 +1,10 @@
+---
+id: d461e173-e5b5-4059-9dea-6232e6bafd07
+type: reference
+tags: [3f6d0af, eval, qa]
+created: 2026-06-29T18:44:48Z
+updated: 2026-06-29T18:44:48Z
+scope: project
+---
+
+eval qa pass_rate=1.0000 passed=10/10 p0_regression=False sha=3f6d0af date=2026-06-29


### PR DESCRIPTION
## Summary

- Adds two framework memory entries recording QA eval pass results (10/10, sha=3f6d0af, 2026-06-29)
- No build artifacts, secrets, or generated junk included — only `.claude/memory/entries/` files

## Classification

| File | Type | Action |
|------|------|--------|
| `.claude/memory/entries/01fbe74a-*.md` | QA eval pass record (type: reference) | Committed |
| `.claude/memory/entries/d461e173-*.md` | QA eval pass record (type: reference) | Committed |

## Test plan
- [ ] Verify memory entries are valid markdown with correct frontmatter
- [ ] Confirm no build artifacts or secrets were included

🤖 Generated with [Claude Code](https://claude.com/claude-code)