### PR TITLE
docs: framework 5.12.0 initiative (cc eval, budget flag, Discord re-arm, CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.12.0] - 2026-06-29
+
+Regression-eval harness, per-task cost cap flag, hook hardening, CLI-owned Discord re-arm architecture, and AI-ecosystem gap audit. Component bumps: cc 1.6.0, tc 1.3.0.
+
+### Added
+
+- **`cc eval` — regression-eval harness** (`tools/cc/`): cross-version regression suite for framework agents. Authors write golden cases in `.claude/evals/<agent>/*.yaml` (input prompt + expected output criteria); `cc eval run [--agent <name>]` executes them via a pluggable pure-Python runner, scores each case, and persists results to `cc memory` for longitudinal tracking. Gate pattern: failing evals on a `cc` or `tc` VERSION.json bump blocks the bump from merging. See `tools/cc/README.md` → Eval section.
+- **`--max-budget-usd <float>` dispatch flag** (`tools/tc/`): per-task cost-cap annotation on `tc task create` and `tc task claim`. The flag plumbing is live (stored in task metadata); enforcement (rejecting a dispatch that would exceed the cap) is a roadmap P1 item. See `tools/tc/README.md` → tc worker section.
+- **AI-ecosystem gap audit report** (`docs/70-reference/ai-ecosystem-research-methodology.md`): cross-product documentation gap inventory produced during the 5.12.0 initiative cycle. WP-173 is the machine-readable form; the committed file is the human-readable reference.
+
+### Changed
+
+- **`pretool-check.sh` hook hardening** (`.claude/hooks/pretool-check.sh`): deny-reason output is now always visible in the hook response (`python3 -c` replaced with `jq` for JSON reads, eliminating the silent-deny regression introduced in 5.11.0). Agents now see the exact rule that fired rather than a blank rejection.
+- **Discord re-arm architecture** — re-arm loop ownership moved from `CLAUDE.md` behavioral instruction to a registered Claude Code Stop hook (`cli-copilot discord install-hook`). The behavioral instruction in `CLAUDE.md` remains as a fallback description; the Stop hook is the runtime mechanism. Pairs with new `cli-copilot` commands `handoff --await`, `stop-hook`, `discord close`, and `COPILOT_DISCORD_LOOP=off` escape (documented in `cli-copilot` README; see the companion instruction-set WP for details).
+
+### Architecture
+
+- **cc 1.6.0**: `cc eval` command family (`eval run`, `eval list`, `eval add`, `eval show`); eval runner and `.claude/evals/` golden-case convention; score persistence to `cc memory`
+- **tc 1.3.0**: `--max-budget-usd` flag on `task create`/`task claim`; `tc worker` dispatch surface (enforcement is roadmap P1)
+
 ## [5.11.0] - 2026-06-25
 
 Safety primitives, cross-model adversarial QA, CONFUSED loop-state, HTML work-product renderer, and `cc memory export`. Inspired in part by **gstack** (Garry Tan, `github.com/garrytan/gstack`, MIT) and **"The Unreasonable Effectiveness of HTML"** (Thariq Shihipar, Anthropic Engineering Blog) — see ADR-004.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,9 +89,10 @@ This file provides guidance to Claude Code when working with the Claude Copilot 
 Persistent memory across sessions with full-text (FTS5 keyword) search.
 
 **Storage:** `.claude/memory/entries/<uuid>.md` (committed, travels with repo)
-**Commands:** `cc memory store`, `cc memory search`, `cc memory get`, `cc memory list`, `cc memory check`
+**Commands:** `cc memory store`, `cc memory search`, `cc memory get`, `cc memory list`, `cc memory check`, `cc eval`
 **Index:** `cc memory index --rebuild` (local SQLite cache, gitignored)
 **Drift detection:** `cc memory check` — token-free deterministic checkers for path-existence, command-resolve, version-conflict, staleness; 0–100 score; exits 1 on any `fail`-severity finding
+**Regression eval:** `cc eval run [--agent <name>]` — golden cases in `.claude/evals/<agent>/*.yaml`; scores persist to `cc memory`; CI gate on VERSION.json bumps
 
 **Location:** `tools/cc/`
 
@@ -123,11 +124,13 @@ Skills auto-fire based on their trigger-rich `description` field — native Clau
 
 Ephemeral PRD, task, and work product storage. Reduces context for externalized work products by ~94% vs inlining outputs above the 8KB threshold (not end-to-end session savings — see [derivation](docs/70-reference/04-framework-modernization-analysis.md)). Uses the `tc` CLI tool (installed at `tools/tc/`). Agents call `tc` commands via Bash.
 
-**Core Commands:** `tc prd create`, `tc task create`, `tc task update`, `tc task get`, `tc wp store`, `tc wp get`, `tc wp render <id> --html`, `tc progress`
+**Core Commands:** `tc prd create`, `tc task create [--max-budget-usd <float>]`, `tc task update`, `tc task get`, `tc wp store`, `tc wp get`, `tc wp render <id> --html`, `tc progress`
 
 **Stream Commands:** `tc stream list`, `tc stream get`
 
 **Collaboration:** `tc handoff`, `tc log --task <id>`
+
+**Dispatch:** `tc worker run <task_id>` (budget cap flag stored in metadata; enforcement is roadmap P1)
 
 **Location:** `tools/tc/`
 

--- a/tools/cc/README.md
+++ b/tools/cc/README.md
@@ -386,6 +386,106 @@ headers are captured verbatim in `raw_headers` for forward-compatibility (R1).
 
 ---
 
+### Eval
+
+`cc eval` is a cross-version regression harness for framework agents. It runs golden-case suites, scores results, and persists scores to `cc memory` so regressions are caught before a component version bump ships.
+
+**Diátaxis mode:** How-to + Reference
+
+#### Golden-case format
+
+Golden cases live in `.claude/evals/<agent>/` as `.yaml` files. Each file describes one case:
+
+```yaml
+# .claude/evals/me/basic-task.yaml
+id: me-basic-task-001
+agent: me
+description: "Implements a simple utility function when given a task"
+input:
+  prompt: "Implement a Python function that returns the factorial of n"
+  task_context: "TASK-001: Factorial utility"
+expected:
+  contains:
+    - "def factorial"
+    - "return"
+  not_contains:
+    - "import math"   # should compute, not delegate
+  score_threshold: 0.8
+```
+
+Fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Unique case identifier (slug format) |
+| `agent` | Yes | Target agent name (matches `.claude/agents/<name>.md`) |
+| `description` | Yes | Human-readable intent of the case |
+| `input.prompt` | Yes | The prompt fed to the agent |
+| `input.task_context` | No | Optional task metadata to seed the run |
+| `expected.contains` | No | Strings that must appear in agent output |
+| `expected.not_contains` | No | Strings that must NOT appear in agent output |
+| `expected.score_threshold` | No | Minimum pass score (0.0–1.0, default 0.7) |
+
+#### Commands
+
+```bash
+# Run all eval cases
+cc eval run
+
+# Run cases for a specific agent
+cc eval run --agent me
+cc eval run --agent qa
+
+# Run a specific case file
+cc eval run --case .claude/evals/me/basic-task.yaml
+
+# List all registered cases
+cc eval list
+cc eval list --agent ta
+
+# Show a specific case with its last-run score
+cc eval show me-basic-task-001
+
+# Register a new golden case interactively
+cc eval add --agent me
+```
+
+#### Score persistence
+
+After each run, `cc eval` stores a `decision`-type memory entry recording the agent name, case ID, score, and pass/fail verdict:
+
+```
+cc memory store --type decision "eval run: agent=me case=me-basic-task-001 score=0.92 verdict=pass"
+```
+
+This lets `cc memory search "eval run agent=me"` retrieve the longitudinal score history without a separate database.
+
+#### CI gate pattern
+
+Add an eval run to your CI pipeline on any `cc` or `tc` version bump in `VERSION.json`:
+
+```bash
+# .github/workflows/eval-gate.yml (excerpt)
+- name: Run agent evals
+  run: cc eval run
+  # Exits 1 if any case scores below its threshold
+```
+
+`cc eval run` exits 1 if any case fails its `score_threshold`; exits 0 on all-pass.
+
+#### Pluggable runner
+
+The eval runner is pure Python with no external dependencies. To swap in a different execution backend (e.g. a local model instead of Claude API), implement `cc.core.eval_runner.EvalRunner` and register it:
+
+```python
+from cc.core.eval_runner import register_runner
+register_runner("local-llm", MyLocalRunner)
+```
+
+The default runner (`"claude"`) is selected by `cc config set eval.runner claude`.
+
+---
+
 ### `cc env` — Agent Shell Hydration
 
 Exports effective config as `CC_*` environment variables, suitable for `eval` in agent preambles:
@@ -523,6 +623,7 @@ tools/cc/
       config.py           # get, set, unset, list, where, validate, edit, init, export, doctor
       env.py              # cc env (shell hydration)
       docs.py             # resolve, get, search, sources, cache (Live Docs)
+      eval.py             # run, list, add, show (Eval harness)
       mcp.py              # serve, config
       doctor.py           # cc doctor (standalone health check)
     api.py                # flat importable facade for code-execution use (memory_store/get/list/search, skill_get/search)

--- a/tools/tc/README.md
+++ b/tools/tc/README.md
@@ -122,11 +122,11 @@ finally:
 ### `tc task`
 
 ```bash
-tc task create  --title "..." --prd <id> --agent <slug> --priority 0-3
+tc task create  --title "..." --prd <id> --agent <slug> --priority 0-3 [--max-budget-usd <float>]
 tc task get     <id> [--json]
 tc task list    [--status pending] [--agent me] [--prd <id>]
 tc task update  <id> --status completed
-tc task claim   <id> --agent <slug>
+tc task claim   <id> --agent <slug> [--max-budget-usd <float>]
 tc task next    [--agent me]
 tc task deps add    <id> --depends-on <id>
 tc task deps remove <id> --depends-on <id>
@@ -177,6 +177,37 @@ tc progress                        # task count by status per stream
 tc handoff --from me --to qa --task <id> --context "..."
 tc log --task <id> [--limit 20]
 ```
+
+### `tc worker`
+
+`tc worker` is the agent-dispatch surface for budget-bounded task execution.
+
+**`--max-budget-usd <float>`** — per-task cost cap. Set it on `tc task create` or `tc task claim` to annotate the maximum USD the dispatched agent is permitted to spend on that task.
+
+```bash
+# Create a task with a $0.50 cost cap
+tc task create --title "Generate unit tests" --prd 1 --agent qa --max-budget-usd 0.50
+
+# Claim a task and declare a cap at claim time
+tc task claim 42 --agent me --max-budget-usd 1.00
+```
+
+The flag is stored in task metadata (`metadata.max_budget_usd`). You can retrieve it:
+
+```bash
+tc task get 42 --json | python3 -c "import sys,json; t=json.load(sys.stdin); print(t.get('metadata',{}).get('max_budget_usd','unset'))"
+```
+
+**Current status — flag plumbing only (tc 1.3.0):** The value is stored and retrievable. Runtime enforcement — rejecting or halting a dispatch that would exceed the cap — is a **roadmap P1** item. Setting the flag now future-proofs your task graph for when enforcement ships.
+
+**`tc worker` subcommand (dispatch surface):**
+
+```bash
+tc worker run   <task_id>   # dispatch task to its assigned agent (respects max_budget_usd when enforcement lands)
+tc worker status <task_id>  # show dispatch state and budget annotation
+```
+
+---
 
 ### `tc deploy`
 


### PR DESCRIPTION
## Summary

- Adds `[5.12.0]` CHANGELOG entry covering all shipped changes: `cc eval` regression harness, `--max-budget-usd` dispatch flag, `pretool-check.sh` python3→jq hook fix, CLI-owned Discord re-arm architecture shift, and AI-ecosystem gap audit
- Documents `cc eval` command family in `tools/cc/README.md` (golden-case YAML convention, score persistence to `cc memory`, CI gate pattern, pluggable runner)
- Documents `--max-budget-usd` flag and `tc worker` dispatch surface in `tools/tc/README.md`
- Updates `CLAUDE.md` Five Pillars cc/tc capability lines to include `cc eval` and `--max-budget-usd`

## Scope

Claude-copilot docs only. cli-copilot and shared-docs updates are captured in WP-174 as a copy-pasteable instruction set.

## Test plan

- [ ] Verify `CHANGELOG.md` [5.12.0] entry appears between [Unreleased] and [5.11.0]
- [ ] Verify `tools/cc/README.md` Eval section renders correctly (headings, code blocks, table)
- [ ] Verify `tools/tc/README.md` tc worker section and updated `tc task create` signature
- [ ] Verify `CLAUDE.md` Memory Copilot commands line includes `cc eval`; Task Copilot line includes `--max-budget-usd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)