### PR TITLE
feat(cc): layered knowledge repos — paths.knowledge_repo accepts an ordered list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.0]
+
+Layered knowledge repos — `paths.knowledge_repo` accepts an ordered list. Component bump: cc 1.7.0.
+
+### Added
+
+- **Layered knowledge repos** (`tools/cc/`): `paths.knowledge_repo` now accepts an ORDERED LIST of repo paths (shared + personal both active simultaneously), in addition to the existing single-string form. A new `resolve_knowledge_repos()` normalizer in `cc.core.config` returns the ordered list for all three supported shapes — legacy string (1-element list), JSON list (order preserved), or null/absent (empty list). Layer precedence for *which source* wins is unchanged (env > project > machine > default); the winning layer supplies the whole ordered list — config layers are never concatenated. Closes the gap between the extension spec's promised layering and the previous single-repo-only implementation.
+- **`cc config add <key> <value>`**: appends a value to a list-valued config key, idempotently (no-op if already present); upgrades an existing string value to a list on first append. Honors `--project`/machine-default scoping like `cc config set`.
+- **`cc config remove <key> <value>`**: symmetric removal from a list-valued config key (no-op if the value is not present).
+- **`CC_PATHS_KNOWLEDGE_REPO` env var now accepts a comma-separated list**: `export CC_PATHS_KNOWLEDGE_REPO="/vol/shared-kc,/vol/personal-kc"` splits into an ordered list (whitespace-trimmed, empty segments dropped). A single path continues to work unchanged.
+- **`cc config set paths.knowledge_repo a,b,c`** parses a comma-separated value into a JSON list for this key only; a single value with no comma is still stored as a plain string (back-compat unaffected for other keys and for existing single-repo configs).
+
+### Changed
+
+- **`cc env`**: `CC_PATHS_KNOWLEDGE_REPO` is now emitted as a comma-joined string when the resolved value is a list. The back-compat alias `CC_KNOWLEDGE_REPO` carries only the **first** element of the list, so agents/hooks reading a single value keep working unchanged.
+- **`cc config doctor`**: path-existence checks now handle list-valued config keys, checking each path in the list individually rather than stringifying the whole list.
+- **`docs/40-extensions/00-extension-spec.md`**: added an "Implementation status" note distinguishing what `cc` resolves deterministically (config values, including the new ordered-list `paths.knowledge_repo`) from the richer per-agent `.override.md`/`.extension.md`/`.skills.json` manifest-merging model the spec describes, which is an agent-read convention, not something `cc` parses or merges automatically. Added a dedicated "Layered Knowledge Repos" section documenting the value shapes, precedence rule, and new `cc config add`/`remove` commands.
+- **`tools/cc/README.md`**: documented the ordered-list value shapes, `cc config add`/`remove`, and the `cc env` comma-join + first-element alias behavior for `paths.knowledge_repo`.
+
+### Architecture
+
+- **cc 1.7.0**: `resolve_knowledge_repos()` normalizer, `LIST_VALUED_KEYS` registry, `add_to_list_config()`/`remove_from_list_config()` in `cc.core.config`; `cc config add`/`remove` CLI commands; comma-split env-var handling for list-valued keys.
+
 ## [5.12.0] - 2026-06-29
 
 Regression-eval harness, per-task cost cap flag, hook hardening, CLI-owned Discord re-arm architecture, and AI-ecosystem gap audit. Component bumps: cc 1.6.0, tc 1.3.0.

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,9 +1,9 @@
 {
-  "framework": "5.12.0",
-  "lastUpdated": "2026-06-29T00:00:00.000Z",
+  "framework": "5.13.0",
+  "lastUpdated": "2026-07-04T00:00:00.000Z",
   "components": {
     "cc": {
-      "version": "1.6.0",
+      "version": "1.7.0",
       "path": "tools/cc",
       "installScript": "tools/cc/install.sh",
       "provides": ["cc memory", "cc memory check", "cc skill", "cc config", "cc env", "cc docs", "cc usage", "cc eval"]

--- a/docs/40-extensions/00-extension-spec.md
+++ b/docs/40-extensions/00-extension-spec.md
@@ -2,11 +2,29 @@
 
 This document defines how knowledge repositories extend Claude-Copilot framework agents.
 
+> **Implementation status (read this first):** `cc` deterministically resolves
+> `paths.knowledge_repo` / `paths.shared_docs` as **config values** — including,
+> since the layered-knowledge-repos feature, an **ordered list** of repo paths
+> (see [Layered Knowledge Repos](#layered-knowledge-repos-ordered-list) below)
+> — and exports them as `CC_*` environment variables via `cc env`. That is the
+> full extent of what `cc` parses and merges automatically today.
+>
+> The richer per-agent model described later in this document — `.override.md` /
+> `.extension.md` / `.skills.json` files, `knowledge-manifest.json` parsing,
+> section-level merging, and `requiredSkills` validation — is **not**
+> implemented by `cc`. It is documented here as an **agent-read convention**:
+> an agent invocation may choose to look inside the resolved knowledge-repo
+> path(s) for these files and interpret them itself, but no `cc` command
+> parses a manifest, merges an `.extension.md` into a base agent, or validates
+> `requiredSkills`. Treat every example below that references manifests,
+> overrides, or skills injection as a **convention for agents to follow**, not
+> a `cc`-resolved behavior, unless explicitly marked otherwise.
+
 ## Overview
 
 Claude-Copilot provides **base agents** with generic, industry-standard methodologies. Knowledge repositories can **extend** these agents with company-specific methodologies, skills, and practices.
 
-The system supports **two-tier resolution**: a global knowledge repository shared across all projects, and optional project-specific overrides.
+The system supports **two-tier resolution**: a global knowledge repository shared across all projects, and optional project-specific overrides. Since the layered-knowledge-repos feature, the value that wins at each tier may itself be an **ordered list of repo paths** rather than a single path — see [Layered Knowledge Repos](#layered-knowledge-repos-ordered-list).
 
 ```
 ┌─────────────────────────────────────┐
@@ -161,6 +179,53 @@ When an agent is invoked, the system uses **two-tier resolution**:
 | (none) | SD override | Uses **global** SD override |
 | uid extension | SD override | uid from project, SD from global |
 | (none) | (none) | Base agents only |
+
+## Layered Knowledge Repos (ordered list)
+
+`paths.knowledge_repo` accepts an **ordered list** of repo paths, not just a
+single path. This lets a project combine a shared team repo with a personal
+one — both are active simultaneously, rather than one replacing the other.
+
+**Value shapes `cc` resolves (implemented, deterministic):**
+
+| Shape | Example | Resolves to |
+|-------|---------|-------------|
+| Legacy string | `"/vol/shared-kc"` | `["/vol/shared-kc"]` |
+| JSON list | `["/vol/shared-kc", "/vol/personal-kc"]` | Same list, in order |
+| Absent / `null` | — | `[]` |
+
+**What does NOT change:** layer precedence for *which source* wins is
+unchanged — `CC_PATHS_KNOWLEDGE_REPO` env var > project config > machine
+config > default. The highest-precedence source that **sets** the key
+supplies the **whole** ordered list; `cc` does not concatenate lists across
+config layers (e.g. it will not merge a machine-layer list with a
+project-layer list). To combine a shared and a personal repo, put both paths
+in one list at whichever layer you control:
+
+```bash
+# Ordered append, idempotent (no duplicate on repeat)
+cc config add paths.knowledge_repo /vol/shared-kc
+cc config add paths.knowledge_repo /vol/personal-kc
+cc config remove paths.knowledge_repo /vol/personal-kc   # symmetric removal
+
+# Or set the whole list at once — comma-separated values parse into a list
+# for this key only (other config keys keep literal commas)
+cc config set paths.knowledge_repo /vol/shared-kc,/vol/personal-kc
+
+# Env override also accepts a comma-separated list
+export CC_PATHS_KNOWLEDGE_REPO="/vol/shared-kc,/vol/personal-kc"
+```
+
+**`cc env` output:** `CC_PATHS_KNOWLEDGE_REPO` is emitted as a comma-joined
+string in resolution order. The back-compat alias `CC_KNOWLEDGE_REPO` carries
+only the **first** element, so agents/hooks reading a single value keep
+working unchanged.
+
+Order in the list is resolution order — index 0 is consulted first if an
+agent (per the agent-read convention above) walks the list looking for
+extension files.
+
+
 
 ## File Structure
 
@@ -389,6 +454,13 @@ The framework automatically checks for a global knowledge repository at `~/.clau
 cc config set paths.knowledge_repo ~/.claude/knowledge
 ```
 
+**Register multiple repos (shared + personal, both active):**
+
+```bash
+cc config add paths.knowledge_repo ~/.claude/knowledge
+cc config add paths.knowledge_repo ~/.claude/knowledge-personal
+```
+
 **With project-specific override:**
 
 Set `KNOWLEDGE_REPO_PATH` only when you need project-specific extensions that differ from global:
@@ -400,6 +472,8 @@ export KNOWLEDGE_REPO_PATH=/path/to/project-specific/knowledge
 # Or register with cc config
 cc config set paths.knowledge_repo /path/to/project-specific/knowledge
 ```
+
+See [Layered Knowledge Repos](#layered-knowledge-repos-ordered-list) for the full value-shape and precedence contract.
 
 > **Note:** The `cc env` command exports these as environment variables. Use `eval "$(cc env)"` in agent preambles.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilot/framework",
-  "version": "5.12.0",
+  "version": "5.13.0",
   "description": "Claude Copilot - AI-enabled development framework",
   "private": true,
   "scripts": {

--- a/tools/cc/README.md
+++ b/tools/cc/README.md
@@ -173,7 +173,12 @@ cc config list --scope project
 # Show which layer provides a key
 cc config where paths.shared_docs
 
-# Remove a key
+# Add / remove a value from a list-valued key, idempotently
+cc config add paths.knowledge_repo /path/to/shared-kc
+cc config add paths.knowledge_repo /path/to/personal-kc
+cc config remove paths.knowledge_repo /path/to/personal-kc
+
+# Remove a key entirely
 cc config unset paths.shared_docs
 cc config unset --project paths.shared_docs
 
@@ -197,6 +202,29 @@ cc config export --mask-secrets
 # Health check
 cc config doctor
 ```
+
+**`paths.knowledge_repo` — layered (ordered list) support:**
+
+`paths.knowledge_repo` accepts three shapes, in order to stay back-compatible with existing single-repo setups while supporting multiple active repos (e.g. a shared team repo plus a personal one):
+
+| Shape | Example | Resolves to |
+|-------|---------|-------------|
+| Legacy string | `"/vol/shared-kc"` | `["/vol/shared-kc"]` (1-element list) |
+| JSON list | `["/vol/shared-kc", "/vol/personal-kc"]` | Same list, in order |
+| Absent / `null` | — | `[]` |
+
+Order matters — index 0 is consulted first. Layer precedence for *which* value wins is unchanged (env > project > machine > default); the winning layer supplies the **whole** list — layers are never concatenated across sources. To combine a shared and a personal repo, put both paths in one list at the layer you control:
+
+```bash
+# Machine config ends up with an ordered 2-repo list
+cc config add paths.knowledge_repo /vol/shared-kc
+cc config add paths.knowledge_repo /vol/personal-kc
+
+# Or set both at once (comma-separated values parse into a list for this key)
+cc config set paths.knowledge_repo /vol/shared-kc,/vol/personal-kc
+```
+
+The `CC_PATHS_KNOWLEDGE_REPO` env var override also accepts a comma-separated list (`export CC_PATHS_KNOWLEDGE_REPO="/vol/shared-kc,/vol/personal-kc"`). `cc env` emits it as a comma-joined string, plus the back-compat `CC_KNOWLEDGE_REPO` alias carrying only the **first** element (for agents/hooks reading a single value).
 
 **`@machine` sentinel example** — in `.claude/cc/config.json`:
 

--- a/tools/cc/src/cc/commands/config.py
+++ b/tools/cc/src/cc/commands/config.py
@@ -13,9 +13,11 @@ from rich.console import Console
 from rich.table import Table
 
 from cc.core.config import (
+    add_to_list_config,
     get_resolved_config,
     load_machine_config,
     load_project_config,
+    remove_from_list_config,
     resolve_key,
     unset_config,
     where_key,
@@ -104,7 +106,13 @@ def config_get(
 @config_app.command("set")
 def config_set(
     key: str = typer.Argument(..., help="Dotted config key."),
-    value: str = typer.Argument(..., help="Value to set."),
+    value: str = typer.Argument(
+        ...,
+        help=(
+            "Value to set. For list-valued keys (e.g. paths.knowledge_repo), "
+            "a comma-separated value (e.g. 'a,b,c') is parsed into a list."
+        ),
+    ),
     project: bool = typer.Option(
         False,
         "--project",
@@ -120,6 +128,62 @@ def config_set(
 
     layer = "project" if project else "machine"
     console.print(f"[green]Set[/green] {key} = {value!r}  ({layer}: {written_path})")
+
+
+@config_app.command("add")
+def config_add(
+    key: str = typer.Argument(
+        ..., help="Dotted config key (list-valued, e.g. paths.knowledge_repo)."
+    ),
+    value: str = typer.Argument(..., help="Value to append to the list."),
+    project: bool = typer.Option(
+        False,
+        "--project",
+        help="Write to project config instead of machine config.",
+    ),
+) -> None:
+    """Append a value to a list-valued config key, idempotently.
+
+    Creates the list if the key was previously a string or unset. A value
+    already present in the list is not duplicated. Order is preserved —
+    the first entry in the list is consulted first at resolution time.
+    """
+    try:
+        written_path = add_to_list_config(key, value, project=project)
+    except ValueError as exc:
+        err_console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1)
+
+    layer = "project" if project else "machine"
+    console.print(f"[green]Added[/green] {value!r} to {key}  ({layer}: {written_path})")
+
+
+@config_app.command("remove")
+def config_remove(
+    key: str = typer.Argument(
+        ..., help="Dotted config key (list-valued, e.g. paths.knowledge_repo)."
+    ),
+    value: str = typer.Argument(..., help="Value to remove from the list."),
+    project: bool = typer.Option(
+        False,
+        "--project",
+        help="Remove from project config instead of machine config.",
+    ),
+) -> None:
+    """Remove a value from a list-valued config key (symmetric to `add`).
+
+    No-op if the value is not present.
+    """
+    try:
+        written_path = remove_from_list_config(key, value, project=project)
+    except ValueError as exc:
+        err_console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1)
+
+    layer = "project" if project else "machine"
+    console.print(
+        f"[green]Removed[/green] {value!r} from {key}  ({layer}: {written_path})"
+    )
 
 
 @config_app.command("unset")

--- a/tools/cc/src/cc/commands/doctor.py
+++ b/tools/cc/src/cc/commands/doctor.py
@@ -84,9 +84,15 @@ def run_doctor(
         v = cfg.get(k)
         if v is None:
             continue
-        p = Path(str(v))
-        if not p.exists():
-            warnings.append(f"Path not found: {k} = {v}")
+        # paths.knowledge_repo (and any future list-valued path key) may
+        # resolve to an ordered list of paths rather than a single scalar.
+        candidates = v if isinstance(v, list) else [v]
+        for item in candidates:
+            if not item:
+                continue
+            p = Path(str(item))
+            if not p.exists():
+                warnings.append(f"Path not found: {k} = {item}")
 
     # --- Machine config dir gitignore ---
     gitignore_path = machine_cfg.parent / ".gitignore"

--- a/tools/cc/src/cc/commands/env.py
+++ b/tools/cc/src/cc/commands/env.py
@@ -47,7 +47,14 @@ def run_env(
         if value is None:
             continue
         env_name = _key_to_env_name(key)
-        exports[env_name] = str(value)
+        if isinstance(value, list):
+            # e.g. paths.knowledge_repo may resolve to an ordered list of
+            # repo paths; emit as a comma-joined string (order preserved).
+            if not value:
+                continue
+            exports[env_name] = ",".join(str(v) for v in value)
+        else:
+            exports[env_name] = str(value)
 
     if include_secrets:
         machine_secrets = load_machine_secrets()
@@ -65,5 +72,12 @@ def run_env(
     for alias, source in _PATH_ALIASES.items():
         if source in exports and alias not in exports:
             exports[alias] = exports[source]
+
+    # CC_KNOWLEDGE_REPO is a single-value back-compat alias: when
+    # paths.knowledge_repo resolves to an ordered list (comma-joined above
+    # into CC_PATHS_KNOWLEDGE_REPO), the alias carries only the FIRST
+    # element so agents reading one value keep working unchanged.
+    if "CC_KNOWLEDGE_REPO" in exports:
+        exports["CC_KNOWLEDGE_REPO"] = exports["CC_KNOWLEDGE_REPO"].split(",")[0].strip()
 
     return exports

--- a/tools/cc/src/cc/core/config.py
+++ b/tools/cc/src/cc/core/config.py
@@ -48,6 +48,24 @@ DEFAULTS: dict[str, Any] = {
     "docs.context7_endpoint": None,
 }
 
+# ---------------------------------------------------------------------------
+# List-valued keys (ordered lists, comma-string affordances)
+# ---------------------------------------------------------------------------
+
+# Config keys whose value may be an ORDERED LIST rather than a single scalar.
+# Currently only paths.knowledge_repo — see resolve_knowledge_repos() below.
+# Each source layer (env / project / machine) still supplies the WHOLE list
+# for this key; layers are never concatenated across sources.
+LIST_VALUED_KEYS: frozenset[str] = frozenset({"paths.knowledge_repo"})
+
+# Sentinel distinguishing "no value passed" from an explicit None argument.
+_UNSET = object()
+
+
+def _split_csv_list(value: str) -> list[str]:
+    """Split a comma-separated string into trimmed, non-empty parts."""
+    return [part.strip() for part in value.split(",") if part.strip()]
+
 
 # ---------------------------------------------------------------------------
 # Flat dict helpers (dotted-key access)
@@ -147,10 +165,40 @@ def load_project_secrets() -> dict[str, str]:
 
 
 def _expand_path(value: Any) -> Any:
-    """Expand ~ in path-like string values."""
+    """Expand ~ in path-like string values (recursively for lists)."""
     if isinstance(value, str) and "~" in value:
         return str(Path(value).expanduser())
+    if isinstance(value, list):
+        return [_expand_path(v) for v in value]
     return value
+
+
+def resolve_knowledge_repos(value: Any = _UNSET) -> list[str]:
+    """
+    Normalize a paths.knowledge_repo config value into an ordered list of paths.
+
+    Accepts all three supported shapes:
+      - None / absent    -> []
+      - a JSON list       -> returned in order (non-empty entries only)
+      - a legacy string   -> single-element list (NOT comma-split; a plain
+                              string is always treated as one path for
+                              back-compat with existing configs)
+
+    If `value` is omitted, resolves "paths.knowledge_repo" from the effective
+    config (env > project > machine > default) via resolve_key().
+
+    Order in the returned list == resolution order (index 0 consulted first).
+    """
+    if value is _UNSET:
+        value = resolve_key("paths.knowledge_repo")
+
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(v) for v in value if v]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return []
 
 
 def get_resolved_config(
@@ -199,7 +247,11 @@ def get_resolved_config(
     for key in list(resolved.keys()):
         env_name = "CC_" + key.replace(".", "_").upper()
         if env_name in os.environ:
-            resolved[key] = os.environ[env_name]
+            raw_env = os.environ[env_name]
+            if key in LIST_VALUED_KEYS:
+                resolved[key] = _split_csv_list(raw_env)
+            else:
+                resolved[key] = raw_env
 
     # Expand ~ in all string values
     resolved = {k: _expand_path(v) for k, v in resolved.items()}
@@ -242,7 +294,10 @@ def resolve_key(
     # Env var first
     env_name = "CC_" + key.replace(".", "_").upper()
     if env_name in os.environ:
-        return _expand_path(os.environ[env_name])
+        raw_env = os.environ[env_name]
+        if key in LIST_VALUED_KEYS:
+            return _expand_path(_split_csv_list(raw_env))
+        return _expand_path(raw_env)
 
     # Project
     if key in project_flat:
@@ -264,8 +319,20 @@ def write_config(key: str, value: Any, *, project: bool = False) -> Path:
     """
     Write a key to the machine or project config file.
 
+    For LIST_VALUED_KEYS (e.g. "paths.knowledge_repo"), a comma-separated
+    string value (e.g. "a,b,c") is parsed into a JSON list before writing.
+    A single value with no comma is stored as a plain string, unchanged
+    (back-compat — existing single-string configs keep working).
+
     Returns the path written to.
     """
+    if (
+        key in LIST_VALUED_KEYS
+        and isinstance(value, str)
+        and "," in value
+    ):
+        value = _split_csv_list(value)
+
     if project:
         cfg_path = project_config_path()
         if cfg_path is None:
@@ -279,6 +346,73 @@ def write_config(key: str, value: Any, *, project: bool = False) -> Path:
     existing = _read_json(cfg_path)
     _dotted_set(existing, key, value)
 
+    cfg_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    return cfg_path
+
+
+def _as_list(current: Any) -> list[Any]:
+    """Coerce an existing config value (None/string/list) into a list copy."""
+    if current is None:
+        return []
+    if isinstance(current, list):
+        return list(current)
+    return [current]
+
+
+def add_to_list_config(key: str, value: str, *, project: bool = False) -> Path:
+    """
+    Append `value` to a list-valued config key, idempotently.
+
+    If the key currently holds a string, it is upgraded to a list (the
+    existing string becomes the first element). If unset, starts a new
+    list. No-op (no duplicate appended) if `value` is already present.
+
+    Returns the path written to.
+    """
+    if project:
+        cfg_path = project_config_path()
+        if cfg_path is None:
+            raise ValueError(
+                "Not inside a git repository; cannot write project config."
+            )
+    else:
+        cfg_path = machine_config_path()
+
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = _read_json(cfg_path)
+    current_list = _as_list(_dotted_get(existing, key))
+
+    if value not in current_list:
+        current_list.append(value)
+
+    _dotted_set(existing, key, current_list)
+    cfg_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    return cfg_path
+
+
+def remove_from_list_config(key: str, value: str, *, project: bool = False) -> Path:
+    """
+    Remove `value` from a list-valued config key (symmetric to add_to_list_config).
+
+    No-op if `value` is not present. If the key was a plain string equal to
+    `value`, it is removed and the key becomes an empty list.
+
+    Returns the path written to.
+    """
+    if project:
+        cfg_path = project_config_path()
+        if cfg_path is None:
+            raise ValueError(
+                "Not inside a git repository; cannot write project config."
+            )
+    else:
+        cfg_path = machine_config_path()
+
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = _read_json(cfg_path)
+    current_list = [v for v in _as_list(_dotted_get(existing, key)) if v != value]
+
+    _dotted_set(existing, key, current_list)
     cfg_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
     return cfg_path
 
@@ -332,8 +466,10 @@ def where_key(key: str) -> dict[str, Any]:
 
     env_name = "CC_" + key.replace(".", "_").upper()
     if env_name in os.environ:
+        raw_env = os.environ[env_name]
+        env_value: Any = _split_csv_list(raw_env) if key in LIST_VALUED_KEYS else raw_env
         return {
-            "value": _expand_path(os.environ[env_name]),
+            "value": _expand_path(env_value),
             "source": "env",
             "reason": f"env var {env_name}",
         }

--- a/tools/cc/tests/test_knowledge_repos.py
+++ b/tools/cc/tests/test_knowledge_repos.py
@@ -1,0 +1,316 @@
+"""Tests for layered knowledge repos: paths.knowledge_repo as an ordered list.
+
+Covers the normalizer (resolve_knowledge_repos), env var comma-split,
+`cc config add`/`remove` idempotency, `cc config set` comma parsing, and
+`cc env` comma-joined output + first-element back-compat alias.
+"""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from cc.core.config import (
+    add_to_list_config,
+    get_resolved_config,
+    remove_from_list_config,
+    resolve_key,
+    resolve_knowledge_repos,
+)
+from cc.main import app
+
+runner = CliRunner()
+
+
+def invoke(*args):
+    return runner.invoke(app, list(args))
+
+
+# ---------------------------------------------------------------------------
+# resolve_knowledge_repos: normalizer for all three shapes
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_string_value_is_one_element_list():
+    assert resolve_knowledge_repos("/shared/knowledge") == ["/shared/knowledge"]
+
+
+def test_normalize_list_value_preserves_order():
+    assert resolve_knowledge_repos(["/shared", "/personal"]) == ["/shared", "/personal"]
+
+
+def test_normalize_none_is_empty_list():
+    assert resolve_knowledge_repos(None) == []
+
+
+def test_normalize_empty_string_is_empty_list():
+    assert resolve_knowledge_repos("") == []
+
+
+def test_normalize_list_drops_falsy_entries():
+    assert resolve_knowledge_repos(["/shared", "", None]) == ["/shared"]
+
+
+def test_normalize_uses_resolve_key_when_no_arg(monkeypatch):
+    monkeypatch.setattr(
+        "cc.core.config.resolve_key",
+        lambda key, **_: ["/a", "/b"] if key == "paths.knowledge_repo" else None,
+    )
+    assert resolve_knowledge_repos() == ["/a", "/b"]
+
+
+# ---------------------------------------------------------------------------
+# Env override: comma-separated string -> ordered list
+# ---------------------------------------------------------------------------
+
+
+def test_env_override_comma_separated_becomes_list(monkeypatch):
+    monkeypatch.setenv("CC_PATHS_KNOWLEDGE_REPO", "/shared/kc, /personal/kc")
+    cfg = get_resolved_config(_machine={}, _project={})
+    assert cfg["paths.knowledge_repo"] == ["/shared/kc", "/personal/kc"]
+
+
+def test_env_override_single_value_still_one_element_list(monkeypatch):
+    monkeypatch.setenv("CC_PATHS_KNOWLEDGE_REPO", "/only/one")
+    cfg = get_resolved_config(_machine={}, _project={})
+    assert cfg["paths.knowledge_repo"] == ["/only/one"]
+
+
+def test_resolve_key_env_override_comma_separated(monkeypatch):
+    monkeypatch.setenv("CC_PATHS_KNOWLEDGE_REPO", "/a,/b,/c")
+    value = resolve_key("paths.knowledge_repo", _machine={}, _project={})
+    assert value == ["/a", "/b", "/c"]
+
+
+def test_env_override_drops_empty_segments(monkeypatch):
+    monkeypatch.setenv("CC_PATHS_KNOWLEDGE_REPO", "/a,,/b, ,")
+    value = resolve_key("paths.knowledge_repo", _machine={}, _project={})
+    assert value == ["/a", "/b"]
+
+
+# ---------------------------------------------------------------------------
+# Layer precedence unchanged: highest-precedence source provides the WHOLE list
+# ---------------------------------------------------------------------------
+
+
+def test_project_list_wins_over_machine_string():
+    """Project sets its own list; machine's string is NOT concatenated in."""
+    cfg = get_resolved_config(
+        _machine={"paths": {"knowledge_repo": "/machine/kc"}},
+        _project={"paths": {"knowledge_repo": ["/proj/a", "/proj/b"]}},
+    )
+    assert cfg["paths.knowledge_repo"] == ["/proj/a", "/proj/b"]
+
+
+def test_machine_list_used_when_project_absent():
+    cfg = get_resolved_config(
+        _machine={"paths": {"knowledge_repo": ["/machine/a", "/machine/b"]}},
+        _project={},
+    )
+    assert cfg["paths.knowledge_repo"] == ["/machine/a", "/machine/b"]
+
+
+# ---------------------------------------------------------------------------
+# cc config add: idempotent append (core function)
+# ---------------------------------------------------------------------------
+
+
+def test_config_add_creates_list_from_unset(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr("cc.core.config.machine_config_path", lambda: cfg_file)
+
+    add_to_list_config("paths.knowledge_repo", "/shared/kc")
+    data = json.loads(cfg_file.read_text())
+    assert data["paths"]["knowledge_repo"] == ["/shared/kc"]
+
+
+def test_config_add_appends_to_existing_list(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"paths": {"knowledge_repo": ["/shared/kc"]}}))
+    monkeypatch.setattr("cc.core.config.machine_config_path", lambda: cfg_file)
+
+    add_to_list_config("paths.knowledge_repo", "/personal/kc")
+    data = json.loads(cfg_file.read_text())
+    assert data["paths"]["knowledge_repo"] == ["/shared/kc", "/personal/kc"]
+
+
+def test_config_add_upgrades_legacy_string_to_list(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"paths": {"knowledge_repo": "/shared/kc"}}))
+    monkeypatch.setattr("cc.core.config.machine_config_path", lambda: cfg_file)
+
+    add_to_list_config("paths.knowledge_repo", "/personal/kc")
+    data = json.loads(cfg_file.read_text())
+    assert data["paths"]["knowledge_repo"] == ["/shared/kc", "/personal/kc"]
+
+
+def test_config_add_is_idempotent(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"paths": {"knowledge_repo": ["/shared/kc"]}}))
+    monkeypatch.setattr("cc.core.config.machine_config_path", lambda: cfg_file)
+
+    add_to_list_config("paths.knowledge_repo", "/shared/kc")
+    data = json.loads(cfg_file.read_text())
+    assert data["paths"]["knowledge_repo"] == ["/shared/kc"]
+
+
+# ---------------------------------------------------------------------------
+# cc config add / remove: CLI commands
+# ---------------------------------------------------------------------------
+
+
+def test_config_add_cli_command(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr("cc.core.config_paths.machine_config_path", lambda: cfg_file)
+    monkeypatch.setattr("cc.core.config.machine_config_path", lambda: cfg_file)
+
+    result = invoke("config", "add", "paths.knowledge_repo", "/shared/kc")
+    assert result.exit_code == 0
+    data = json.loads(cfg_file.read_text())
+    assert data["paths"]["knowledge_repo"] == ["/shared/kc"]
+
+    # Second add of the same value is a no-op (idempotent)
+    invoke("config", "add", "paths.knowledge_repo", "/shared/kc")
+    data = json.loads(cfg_file.read_text())
+    assert data["paths"]["knowledge_repo"] == ["/shared/kc"]
+
+
+def test_config_add_project_scope(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "project_config.json"
+    monkeypatch.setattr("cc.core.config_paths.project_config_path", lambda: cfg_file)
+    monkeypatch.setattr("cc.core.config.project_config_path", lambda: cfg_file)
+
+    result = invoke("config", "add", "paths.knowledge_repo", "/proj/kc", "--project")
+    assert result.exit_code == 0
+    data = json.loads(cfg_file.read_text())
+    assert data["paths"]["knowledge_repo"] == ["/proj/kc"]
+
+
+def test_config_remove_deletes_value(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(
+        json.dumps({"paths": {"knowledge_repo": ["/shared/kc", "/personal/kc"]}})
+    )
+    monkeypatch.setattr("cc.core.config.machine_config_path", lambda: cfg_file)
+
+    remove_from_list_config("paths.knowledge_repo", "/shared/kc")
+    data = json.loads(cfg_file.read_text())
+    assert data["paths"]["knowledge_repo"] == ["/personal/kc"]
+
+
+def test_config_remove_is_noop_when_absent(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"paths": {"knowledge_repo": ["/shared/kc"]}}))
+    monkeypatch.setattr("cc.core.config.machine_config_path", lambda: cfg_file)
+
+    remove_from_list_config("paths.knowledge_repo", "/not/there")
+    data = json.loads(cfg_file.read_text())
+    assert data["paths"]["knowledge_repo"] == ["/shared/kc"]
+
+
+def test_config_remove_cli_command(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(
+        json.dumps({"paths": {"knowledge_repo": ["/shared/kc", "/personal/kc"]}})
+    )
+    monkeypatch.setattr("cc.core.config_paths.machine_config_path", lambda: cfg_file)
+    monkeypatch.setattr("cc.core.config.machine_config_path", lambda: cfg_file)
+
+    result = invoke("config", "remove", "paths.knowledge_repo", "/shared/kc")
+    assert result.exit_code == 0
+    data = json.loads(cfg_file.read_text())
+    assert data["paths"]["knowledge_repo"] == ["/personal/kc"]
+
+
+# ---------------------------------------------------------------------------
+# cc config set: comma-separated value becomes a list for this key only
+# ---------------------------------------------------------------------------
+
+
+def test_config_set_comma_separated_parses_to_list(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr("cc.core.config_paths.machine_config_path", lambda: cfg_file)
+    monkeypatch.setattr("cc.core.config.machine_config_path", lambda: cfg_file)
+
+    result = invoke("config", "set", "paths.knowledge_repo", "/shared/kc,/personal/kc")
+    assert result.exit_code == 0
+    data = json.loads(cfg_file.read_text())
+    assert data["paths"]["knowledge_repo"] == ["/shared/kc", "/personal/kc"]
+
+
+def test_config_set_single_value_stays_a_string(monkeypatch, tmp_path):
+    """Back-compat: a single value (no comma) is stored as a plain string."""
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr("cc.core.config_paths.machine_config_path", lambda: cfg_file)
+    monkeypatch.setattr("cc.core.config.machine_config_path", lambda: cfg_file)
+
+    result = invoke("config", "set", "paths.knowledge_repo", "/shared/kc")
+    assert result.exit_code == 0
+    data = json.loads(cfg_file.read_text())
+    assert data["paths"]["knowledge_repo"] == "/shared/kc"
+
+
+def test_config_set_other_keys_unaffected_by_comma_splitting(monkeypatch, tmp_path):
+    """Comma-parsing is scoped to LIST_VALUED_KEYS; other keys keep commas literal."""
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr("cc.core.config_paths.machine_config_path", lambda: cfg_file)
+    monkeypatch.setattr("cc.core.config.machine_config_path", lambda: cfg_file)
+
+    result = invoke("config", "set", "docs.source_order", "local,fetch")
+    assert result.exit_code == 0
+    data = json.loads(cfg_file.read_text())
+    assert data["docs"]["source_order"] == "local,fetch"
+
+
+# ---------------------------------------------------------------------------
+# cc env: comma-joined list + first-element back-compat alias
+# ---------------------------------------------------------------------------
+
+
+def test_env_emits_comma_joined_list_for_knowledge_repo(monkeypatch):
+    monkeypatch.setattr(
+        "cc.commands.env.get_resolved_config",
+        lambda **_: {"paths.knowledge_repo": ["/shared/kc", "/personal/kc"]},
+    )
+
+    result = invoke("env")
+    assert result.exit_code == 0
+    assert 'export CC_PATHS_KNOWLEDGE_REPO="/shared/kc,/personal/kc"' in result.output
+
+
+def test_env_knowledge_repo_alias_is_first_element_only(monkeypatch):
+    monkeypatch.setattr(
+        "cc.commands.env.get_resolved_config",
+        lambda **_: {"paths.knowledge_repo": ["/shared/kc", "/personal/kc"]},
+    )
+
+    result = invoke("env")
+    assert result.exit_code == 0
+    assert 'export CC_KNOWLEDGE_REPO="/shared/kc"' in result.output
+    # Full ordered list still available under the long-form key
+    assert 'export CC_PATHS_KNOWLEDGE_REPO="/shared/kc,/personal/kc"' in result.output
+
+
+def test_env_knowledge_repo_alias_still_works_for_single_string(monkeypatch):
+    """Back-compat: unchanged behavior when value is still a plain string."""
+    monkeypatch.setattr(
+        "cc.commands.env.get_resolved_config",
+        lambda **_: {"paths.knowledge_repo": "/only/one"},
+    )
+
+    result = invoke("env")
+    assert result.exit_code == 0
+    assert 'export CC_KNOWLEDGE_REPO="/only/one"' in result.output
+
+
+def test_env_empty_list_is_skipped(monkeypatch):
+    monkeypatch.setattr(
+        "cc.commands.env.get_resolved_config",
+        lambda **_: {"paths.knowledge_repo": []},
+    )
+
+    result = invoke("env")
+    assert result.exit_code == 0
+    assert "CC_PATHS_KNOWLEDGE_REPO" not in result.output
+    assert "CC_KNOWLEDGE_REPO" not in result.output


### PR DESCRIPTION
Makes `cc`'s `paths.knowledge_repo` accept an **ordered list** of knowledge repos so multiple layers (e.g. a shared repo + a personal repo) can be active at once, resolved in order. Closes a gap where the extension spec promised layering but `cc` resolved only a single knowledge repo.

**What changed**
- `paths.knowledge_repo` accepts a string (legacy, 1-element), a JSON list (ordered), or null (empty) via a new `resolve_knowledge_repos()` normalizer. Existing string configs keep working unchanged.
- `CC_PATHS_KNOWLEDGE_REPO` env override accepts a comma-separated list.
- New `cc config add` / `cc config remove` for idempotent list mutation; `cc config set` parses comma-separated values for this key only.
- `cc env` emits the comma-joined list plus a first-element `CC_KNOWLEDGE_REPO` alias for back-compat. All consumers updated.
- Extension spec corrected with an implementation-status note (deterministic resolution vs. agent-read convention).
- Version: cc 1.7.0, framework 5.13.0 (package.json synced); CHANGELOG updated.

**Tests:** full cc suite 640 passed / 0 failed; new `test_knowledge_repos.py` (28) passing. QA-verified real CLI behavior in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)