### PR TITLE
chore(cc): sync package version to 1.7.0

### DIFF
--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "1.5.0"
+version = "1.7.0"
 description = "Unified CLI replacing copilot-memory and skills-copilot MCP servers"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI — unified replacement for copilot-memory and skills-copilot MCP servers."""
 
-__version__ = "1.5.0"
+__version__ = "1.7.0"


### PR DESCRIPTION
Syncs `tools/cc/__init__.py` and `pyproject.toml` (both `1.5.0`) to the authoritative `VERSION.json` `components.cc = 1.7.0`. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)