### PR TITLE
fix(onboard): validate and rollback manifest transactions

### DIFF
--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "1.7.8"
+version = "1.7.9"
 description = "Unified CLI replacing copilot-memory and skills-copilot MCP servers"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI — unified replacement for copilot-memory and skills-copilot MCP servers."""
 
-__version__ = "1.7.8"
+__version__ = "1.7.9"

--- a/tools/cc/src/cc/commands/onboard.py
+++ b/tools/cc/src/cc/commands/onboard.py
@@ -22,7 +22,12 @@ from cc.commands.doctor import build_doctor_report
 from cc.commands.update import execute_update
 from cc.core import authstore, keychain
 from cc.core.config import resolve_key, write_config
-from cc.core.ecosystem.manifest import ManifestError, validate_layers
+from cc.core.ecosystem.manifest import (
+    ManifestError,
+    load_layers,
+    normalize_layer_product,
+    validate_layers,
+)
 from cc.core.ecosystem.ssh_identity import ensure_machine_ssh_identity
 from cc.core.write_guard import assert_write_is_isolated
 
@@ -732,13 +737,14 @@ def _atomic_yaml(path: Path, payload: dict[str, Any]) -> None:
     os.replace(temp, path)
 
 
-def _normalized_existing_manifest(path: Path) -> dict[str, Any]:
-    """Load a supported manifest and translate the retired component key.
+def _existing_manifest(path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Load a supported manifest without rewriting unrequested products.
 
     The first CLI inheritance release called the product discriminator
     ``component``. It is a deterministic predecessor of ``product`` and can
-    therefore be adopted without interpreting user-authored content. Any
-    other structural difference remains a hold for review.
+    therefore be compared through a normalized view. The raw view is retained
+    for serialization so onboarding Claude or Codex cannot rewrite a CLI,
+    Knowledge, or future product layer as an unrelated side effect.
     """
     try:
         raw = yaml.safe_load(path.read_text(encoding="utf-8"))
@@ -761,15 +767,7 @@ def _normalized_existing_manifest(path: Path) -> dict[str, Any]:
             raise ManifestError(
                 "The existing layer manifest contains an unfamiliar layer."
             )
-        layer = dict(raw_layer)
-        component = layer.pop("component", None)
-        product = layer.get("product")
-        if product is None and isinstance(component, str) and component:
-            layer["product"] = component
-        elif component is not None and component != product:
-            raise ManifestError(
-                "The existing layer manifest disagrees about a layer's product."
-            )
+        layer = normalize_layer_product(raw_layer)
         layer.setdefault("activation", "always")
         if not _safe_repository_reference((layer.get("source") or {}).get("repo")):
             raise ManifestError(
@@ -777,10 +775,9 @@ def _normalized_existing_manifest(path: Path) -> dict[str, Any]:
             )
         normalized.append(layer)
     validate_layers(normalized)
-    result: dict[str, Any] = {"version": 1, "layers": normalized}
-    if isinstance(raw.get("org"), str) and raw["org"]:
-        result["org"] = raw["org"]
-    return result
+    normalized_result = dict(raw)
+    normalized_result["layers"] = normalized
+    return raw, normalized_result
 
 
 def _managed_product_is_compatible(
@@ -884,7 +881,7 @@ def _manifest_adoption_plan(
                 None,
             )
     try:
-        existing = _normalized_existing_manifest(source)
+        existing_raw, existing = _existing_manifest(source)
     except ManifestError:
         return ManifestAdoption(
             "unfamiliar",
@@ -898,9 +895,11 @@ def _manifest_adoption_plan(
     desired_layers = list(desired["layers"])
     desired_products = {layer["product"] for layer in desired_layers}
     retained = [
-        layer
-        for layer in existing["layers"]
-        if layer["product"] not in desired_products
+        raw_layer
+        for raw_layer, normalized_layer in zip(
+            existing_raw["layers"], existing["layers"], strict=True
+        )
+        if normalized_layer["product"] not in desired_products
     ]
     existing_managed = [
         layer for layer in existing["layers"] if layer["product"] in desired_products
@@ -917,13 +916,32 @@ def _manifest_adoption_plan(
             None,
         )
 
-    merged = {
-        "version": 1,
-        "org": desired.get("org"),
-        "layers": [*retained, *desired_layers],
-    }
+    existing_org = existing_raw.get("org")
+    desired_org = desired.get("org")
+    if existing_org not in (None, desired_org):
+        return ManifestAdoption(
+            "conflict",
+            "review",
+            "This manifest belongs to a different organization, so I won't replace it.",
+            source,
+            destination,
+            None,
+        )
+    merged = dict(existing_raw)
+    merged["version"] = 1
+    if desired_org:
+        merged["org"] = desired_org
+    merged["layers"] = [*retained, *desired_layers]
     try:
-        validate_layers(merged["layers"])
+        validate_layers(
+            [
+                {
+                    **normalize_layer_product(layer),
+                    "activation": layer.get("activation", "always"),
+                }
+                for layer in merged["layers"]
+            ]
+        )
     except ManifestError:
         return ManifestAdoption(
             "conflict",
@@ -934,7 +952,7 @@ def _manifest_adoption_plan(
             None,
         )
 
-    if source == destination and existing == merged:
+    if source == destination and existing_raw == merged:
         return ManifestAdoption(
             "ready",
             "reuse",
@@ -995,6 +1013,178 @@ def _apply_manifest_adoption(plan: ManifestAdoption) -> Path | None:
         if backup is not None and plan.source.read_bytes() == backup.read_bytes():
             plan.source.unlink()
     return backup
+
+
+def _atomic_bytes(path: Path, content: bytes) -> None:
+    """Replace one controlled file while preserving its exact prior bytes."""
+    assert_write_is_isolated(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("wb", dir=path.parent, delete=False) as handle:
+        handle.write(content)
+        temp = Path(handle.name)
+    os.replace(temp, path)
+
+
+def _rollback_manifest_adoption(plan: ManifestAdoption, backup: Path | None) -> bool:
+    """Restore the exact pre-transaction manifest when a later gate fails.
+
+    The rollback refuses to overwrite concurrent edits: the destination must
+    still equal the payload this transaction wrote, and a migrated source must
+    still be absent (or already equal its backup).
+    """
+    if plan.action == "reuse":
+        return True
+    expected = yaml.safe_dump(plan.payload, sort_keys=False).encode()
+    try:
+        if not plan.destination.is_file() or plan.destination.read_bytes() != expected:
+            return False
+        if plan.source is None:
+            plan.destination.unlink()
+            return True
+        if backup is None or not backup.is_file():
+            return False
+        prior = backup.read_bytes()
+        if plan.source == plan.destination:
+            _atomic_bytes(plan.destination, prior)
+            return True
+        if plan.source.exists() and plan.source.read_bytes() != prior:
+            return False
+        if not plan.source.exists():
+            _atomic_bytes(plan.source, prior)
+        plan.destination.unlink()
+        return True
+    except OSError:
+        return False
+
+
+def _copilot_layers_payload(manifest_path: Path) -> tuple[dict[str, Any] | None, str]:
+    """Ask the installed CLI to resolve one candidate manifest."""
+    executable = shutil.which("copilot")
+    if executable is None:
+        return None, "The installed `copilot` command is unavailable."
+    environment = os.environ.copy()
+    environment["COPILOT_LAYERS_FILE"] = str(manifest_path)
+    try:
+        result = subprocess.run(
+            (str(Path(executable).resolve()), "--json", "layers"),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=environment,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, f"The installed `copilot` reader could not be checked: {exc}"
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        return None, f"The installed `copilot` reader rejected the manifest: {detail}"
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None, "The installed `copilot` reader returned unreadable output."
+    if not isinstance(payload, dict):
+        return None, "The installed `copilot` reader returned an unfamiliar report."
+    return payload, ""
+
+
+def _probe_cli_candidate(candidate: Path, baseline: Path | None) -> dict[str, str]:
+    """Reject a candidate that removes CLI layers or visible capabilities."""
+    candidate_layers = load_layers(candidate)
+    expected_chain = [
+        {
+            "id": layer["id"],
+            "role": layer["role"],
+            "rank": layer["rank"],
+            "repo": layer["source"]["repo"],
+            "ref": layer["source"].get("ref"),
+            "auth": layer["auth"],
+            "unit": layer.get("unit"),
+        }
+        for layer in candidate_layers
+        if layer["product"] == "cli"
+    ]
+    if not expected_chain:
+        return {"result": "ready"}
+
+    candidate_payload, detail = _copilot_layers_payload(candidate)
+    if candidate_payload is None:
+        return {"result": "blocked", "detail": detail}
+    resolved_chain = [
+        {
+            key: layer.get(key)
+            for key in ("id", "role", "rank", "repo", "ref", "auth", "unit")
+        }
+        for layer in candidate_payload.get("chain", [])
+        if isinstance(layer, dict)
+    ]
+    if resolved_chain != expected_chain:
+        return {
+            "result": "blocked",
+            "detail": (
+                "The installed `copilot` reader would change or lose CLI layers "
+                f"(expected {[item['id'] for item in expected_chain]}, "
+                f"resolved {[item['id'] for item in resolved_chain]})."
+            ),
+        }
+
+    if baseline is not None and baseline.is_file():
+        baseline_payload, _ = _copilot_layers_payload(baseline)
+        if baseline_payload is not None:
+            before = {
+                service.get("name"): (service.get("tier"), service.get("mode"))
+                for service in baseline_payload.get("services", [])
+                if isinstance(service, dict) and service.get("name")
+            }
+            after = {
+                service.get("name"): (service.get("tier"), service.get("mode"))
+                for service in candidate_payload.get("services", [])
+                if isinstance(service, dict) and service.get("name")
+            }
+            changed = sorted(
+                name
+                for name, provenance in before.items()
+                if after.get(name) != provenance
+            )
+            if changed:
+                return {
+                    "result": "blocked",
+                    "detail": (
+                        "The candidate would remove or downgrade installed CLI "
+                        "capabilities: " + ", ".join(changed)
+                    ),
+                }
+    return {"result": "ready"}
+
+
+def _validate_manifest_candidate(
+    plan: ManifestAdoption,
+    probe: Callable[[Path, Path | None], dict[str, str]],
+) -> dict[str, str]:
+    """Validate staged bytes with cc and every relevant installed consumer."""
+    if plan.payload is None:
+        return {
+            "result": "blocked",
+            "detail": "No safe layer-manifest candidate was available.",
+        }
+    if plan.action == "reuse":
+        candidate = plan.destination
+        if not candidate.is_file() and plan.source is not None:
+            candidate = plan.source
+        return probe(candidate, plan.source)
+
+    with tempfile.TemporaryDirectory(prefix="cc-manifest-candidate-") as temp_root:
+        candidate = Path(temp_root) / "copilot.layers.yml"
+        candidate.write_text(
+            yaml.safe_dump(plan.payload, sort_keys=False), encoding="utf-8"
+        )
+        try:
+            validate_layers(load_layers(candidate))
+        except ManifestError as exc:
+            return {
+                "result": "blocked",
+                "detail": f"The staged layer manifest is invalid: {exc}",
+            }
+        return probe(candidate, plan.source)
 
 
 def _provision_store(store: dict[str, Any], *, apply: bool, run: Run) -> dict[str, Any]:
@@ -1238,6 +1428,7 @@ def build_ecosystem_onboard_report(
     codex_fn: Callable[..., dict[str, Any]] | None = None,
     update_fn: Callable[..., tuple[dict[str, Any], int]] | None = None,
     doctor_fn: Callable[..., dict[str, Any]] | None = None,
+    consumer_probe_fn: Callable[[Path, Path | None], dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     """Run the resumable Admin-handoff-to-healthy-machine transaction.
 
@@ -1272,6 +1463,8 @@ def build_ecosystem_onboard_report(
         update_fn = execute_update
     if doctor_fn is None:
         doctor_fn = build_doctor_report
+    if consumer_probe_fn is None:
+        consumer_probe_fn = _probe_cli_candidate
 
     normalized = tuple(dict.fromkeys(value.strip().lower() for value in products))
     org = org.strip()
@@ -1341,7 +1534,10 @@ def build_ecosystem_onboard_report(
         "github-personal": f"{personal['owner']}/{normalized[0]}-copilot-private",
     }
     ssh = ssh_fn(
-        apply=False, run=run, adopt_existing=adopt_existing, verify_repos=ssh_verify_repos
+        apply=False,
+        run=run,
+        adopt_existing=adopt_existing,
+        verify_repos=ssh_verify_repos,
     )
     stages.append({"stage": "device-ssh", **_ssh_stage_fields(ssh)})
     inventory.extend(_ssh_inventory(ssh))
@@ -1364,6 +1560,16 @@ def build_ecosystem_onboard_report(
         }
     )
     if adoption.action == "review":
+        return _ecosystem_result(
+            org, normalized, apply, "blocked", stages, manifest["layers"], inventory
+        )
+    candidate = _validate_manifest_candidate(adoption, consumer_probe_fn)
+    if candidate["result"] == "blocked":
+        manifest_stage = next(
+            stage for stage in stages if stage["stage"] == "layer-manifest"
+        )
+        manifest_stage["result"] = "blocked"
+        manifest_stage["detail"] = candidate["detail"]
         return _ecosystem_result(
             org, normalized, apply, "blocked", stages, manifest["layers"], inventory
         )
@@ -1404,7 +1610,10 @@ def build_ecosystem_onboard_report(
         )
 
     ssh = ssh_fn(
-        apply=True, run=run, adopt_existing=adopt_existing, verify_repos=ssh_verify_repos
+        apply=True,
+        run=run,
+        adopt_existing=adopt_existing,
+        verify_repos=ssh_verify_repos,
     )
     ssh_stage = next(stage for stage in stages if stage["stage"] == "device-ssh")
     ssh_stage.update(_ssh_stage_fields(ssh))
@@ -1422,14 +1631,48 @@ def build_ecosystem_onboard_report(
         )
 
     backup = _apply_manifest_adoption(adoption)
-    write_config("layers.manifest", str(target))
     manifest_stage = next(
         stage for stage in stages if stage["stage"] == "layer-manifest"
     )
     manifest_stage["result"] = "reused" if adoption.action == "reuse" else "applied"
     if backup is not None:
         manifest_stage["rollback_path"] = str(backup)
-    update, update_exit = update_fn(dry_run=False)
+
+    def blocked_after_write(detail: str) -> dict[str, Any]:
+        rolled_back = _rollback_manifest_adoption(adoption, backup)
+        prior_manifest = adoption.source
+        if (
+            rolled_back
+            and prior_manifest is not None
+            and prior_manifest.is_file()
+            and adoption.action != "reuse"
+        ):
+            try:
+                _, restore_exit = update_fn(
+                    dry_run=False, _manifest_path=prior_manifest
+                )
+                rolled_back = restore_exit == 0
+            except Exception:
+                rolled_back = False
+        manifest_stage["result"] = "rolled-back" if rolled_back else "rollback-failed"
+        manifest_stage["detail"] = (
+            f"{detail} The previous manifest was restored."
+            if rolled_back
+            else (
+                f"{detail} Automatic rollback could not be proven complete; "
+                f"use {backup} to recover before continuing."
+                if backup is not None
+                else f"{detail} Automatic rollback could not be proven complete."
+            )
+        )
+        return _ecosystem_result(
+            org, normalized, True, "blocked", stages, manifest["layers"], inventory
+        )
+
+    try:
+        update, update_exit = update_fn(dry_run=False, _manifest_path=target)
+    except Exception as exc:
+        return blocked_after_write(f"Materialization failed: {exc}")
     stages.append(
         {
             "stage": "materialize",
@@ -1438,16 +1681,26 @@ def build_ecosystem_onboard_report(
             "held": len(update.get("held_for_approval", [])),
         }
     )
+    if update_exit != 0:
+        return blocked_after_write(
+            "Materialization rejected the candidate layer manifest."
+        )
     if update_exit == 0 and "codex" in normalized:
-        codex_report = codex_fn(apply=True, run=run)
+        try:
+            codex_report = codex_fn(apply=True, run=run)
+        except Exception as exc:
+            return blocked_after_write(f"Codex activation failed: {exc}")
         next(stage for stage in stages if stage["stage"] == "codex-plugin").update(
             codex_report
         )
         if codex_report["result"] == "blocked":
-            return _ecosystem_result(
-                org, normalized, True, "blocked", stages, manifest["layers"], inventory
+            return blocked_after_write(
+                "Codex activation rejected the candidate layer manifest."
             )
-    doctor = doctor_fn()
+    try:
+        doctor = doctor_fn(_manifest_path=target)
+    except Exception as exc:
+        return blocked_after_write(f"The post-apply health check failed: {exc}")
     stages.append(
         {
             "stage": "doctor",
@@ -1455,11 +1708,18 @@ def build_ecosystem_onboard_report(
             "score": doctor.get("score"),
         }
     )
-    result = (
-        "ready" if update_exit == 0 and doctor.get("status") == "healthy" else "blocked"
-    )
+    if doctor.get("status") != "healthy":
+        return blocked_after_write(
+            "The candidate made the post-apply health check unhealthy."
+        )
+    try:
+        write_config("layers.manifest", str(target))
+    except Exception as exc:
+        return blocked_after_write(
+            f"The manifest pointer could not be committed: {exc}"
+        )
     return _ecosystem_result(
-        org, normalized, True, result, stages, manifest["layers"], inventory
+        org, normalized, True, "ready", stages, manifest["layers"], inventory
     )
 
 

--- a/tools/cc/src/cc/core/ecosystem/manifest.py
+++ b/tools/cc/src/cc/core/ecosystem/manifest.py
@@ -42,6 +42,30 @@ class ManifestError(ValueError):
     """
 
 
+def normalize_layer_product(layer: dict[str, Any]) -> dict[str, Any]:
+    """Return one layer with the retired ``component`` key canonicalized.
+
+    ``component`` was the discriminator in the first shared-manifest release.
+    Readers must accept that predecessor throughout the rolling migration so
+    one product cannot disappear merely because another writer adopts the
+    canonical ``product`` spelling. Conflicting dual declarations are never
+    guessed through.
+    """
+    normalized = dict(layer)
+    component = normalized.pop("component", None)
+    product = normalized.get("product")
+    if product is None and isinstance(component, str) and component:
+        normalized["product"] = component
+    elif component is not None and component != product:
+        layer_id = normalized.get("id") or "<unnamed layer>"
+        raise ManifestError(
+            f"Layer {layer_id!r} disagrees between `product` and legacy "
+            "`component`; make the declarations match before continuing."
+        )
+    normalized.setdefault("activation", "always")
+    return normalized
+
+
 def load_layers(source: Path | str | list[dict[str, Any]]) -> list[dict[str, Any]]:
     """
     Load the raw layer list from either:
@@ -54,7 +78,7 @@ def load_layers(source: Path | str | list[dict[str, Any]]) -> list[dict[str, Any
     on the returned layers.
     """
     if isinstance(source, list):
-        return [dict(layer) for layer in source]
+        return [normalize_layer_product(layer) for layer in source]
 
     path = Path(source).expanduser()
     if not path.exists():
@@ -83,7 +107,14 @@ def load_layers(source: Path | str | list[dict[str, Any]]) -> list[dict[str, Any
             f"Layer manifest at {path}: `layers` must be a list, got {type(layers).__name__}."
         )
 
-    return [dict(layer) for layer in layers]
+    normalized: list[dict[str, Any]] = []
+    for layer in layers:
+        if not isinstance(layer, dict):
+            raise ManifestError(
+                f"Layer manifest at {path}: every `layers` entry must be an object."
+            )
+        normalized.append(normalize_layer_product(layer))
+    return normalized
 
 
 def validate_layers(layers: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tools/cc/tests/test_ecosystem_manifest.py
+++ b/tools/cc/tests/test_ecosystem_manifest.py
@@ -80,6 +80,51 @@ layers:
     assert layers[0]["rank"] == 10
 
 
+def test_load_layers_accepts_legacy_component_without_mutating_source(tmp_path):
+    manifest_path = tmp_path / "copilot.layers.yml"
+    manifest_path.write_text(
+        """version: 1
+layers:
+  - id: cli-foundation
+    role: foundation
+    rank: 40
+    component: cli
+    source: {repo: https://example.invalid/cli.git}
+    auth: anon
+    activation: always
+""",
+        encoding="utf-8",
+    )
+    before = manifest_path.read_bytes()
+
+    layers = load_layers(manifest_path)
+
+    assert layers[0]["product"] == "cli"
+    assert "component" not in layers[0]
+    assert manifest_path.read_bytes() == before
+
+
+def test_load_layers_rejects_conflicting_product_and_component(tmp_path):
+    manifest_path = tmp_path / "copilot.layers.yml"
+    manifest_path.write_text(
+        """version: 1
+layers:
+  - id: cli-foundation
+    role: foundation
+    rank: 40
+    product: codex
+    component: cli
+    source: {repo: https://example.invalid/cli.git}
+    auth: anon
+    activation: always
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ManifestError, match="disagrees"):
+        load_layers(manifest_path)
+
+
 def test_load_layers_missing_file_is_plain_language_error(tmp_path):
     missing = tmp_path / "does-not-exist.yml"
     with pytest.raises(ManifestError) as exc_info:

--- a/tools/cc/tests/test_onboard_contract.py
+++ b/tools/cc/tests/test_onboard_contract.py
@@ -486,6 +486,10 @@ def _codex(*, apply, **_kwargs):
     return {"result": "ready" if apply else "changes-required"}
 
 
+def _consumer_ready(*_args):
+    return {"result": "ready"}
+
+
 def test_ecosystem_plan_builds_two_isolated_three_layer_stacks(tmp_path):
     report = build_ecosystem_onboard_report(
         org="Acme",
@@ -495,6 +499,7 @@ def test_ecosystem_plan_builds_two_isolated_three_layer_stacks(tmp_path):
         personal_fn=_personal,
         ssh_fn=_ssh,
         codex_fn=_codex,
+        consumer_probe_fn=_consumer_ready,
     )
     assert report["result"] == "changes-required"
     assert [
@@ -533,9 +538,12 @@ def test_ecosystem_plan_offers_adoptable_ssh_alias_instead_of_blocking(tmp_path)
         personal_fn=_personal,
         ssh_fn=_ssh_adoptable,
         codex_fn=_codex,
+        consumer_probe_fn=_consumer_ready,
     )
     assert report["result"] == "changes-required"
-    ssh_stage = next(stage for stage in report["stages"] if stage["stage"] == "device-ssh")
+    ssh_stage = next(
+        stage for stage in report["stages"] if stage["stage"] == "device-ssh"
+    )
     assert ssh_stage["config"] == "adoptable"
     # The stage dict only ever carries the schema's whitelisted fields --
     # the richer adoption fields belong to the inventory row, not the stage.
@@ -587,11 +595,12 @@ layers:
     )
 
     assert plan.action == "repair"
-    assert [(layer["product"], layer["id"]) for layer in plan.payload["layers"]] == [
-        ("cli", "cli-organization"),
-        ("claude", "claude-personal"),
-    ]
-    assert plan.payload["layers"][0]["activation"] == "always"
+    retained, managed = plan.payload["layers"]
+    assert retained["id"] == "cli-organization"
+    assert retained["component"] == "cli"
+    assert "product" not in retained
+    assert "activation" not in retained
+    assert managed["product"] == "claude"
 
 
 def test_manifest_plan_holds_managed_id_with_different_repository(tmp_path):
@@ -678,7 +687,9 @@ layers:
     assert plan.action == "migrate"
     assert backup is not None and backup.read_bytes() == before
     assert not legacy.exists()
-    assert yaml.safe_load(target.read_text())["layers"][0]["product"] == "cli"
+    retained = yaml.safe_load(target.read_text())["layers"][0]
+    assert retained["component"] == "cli"
+    assert "product" not in retained
 
 
 def test_manifest_repair_is_not_a_checkbox_and_applies_without_any_consent(tmp_path):
@@ -709,12 +720,13 @@ layers:
         personal_fn=_personal,
         ssh_fn=_ssh,
         codex_fn=_codex,
+        consumer_probe_fn=_consumer_ready,
         adopt_existing=(),  # explicit: nobody consented to anything
         update_fn=lambda **_: (
             {"result": "up-to-date", "blocked": [], "held_for_approval": []},
             0,
         ),
-        doctor_fn=lambda: {"status": "healthy", "score": 100},
+        doctor_fn=lambda **_: {"status": "healthy", "score": 100},
     )
     manifest_stage = next(s for s in report["stages"] if s["stage"] == "layer-manifest")
     assert manifest_stage["action"] == "repair"
@@ -722,9 +734,206 @@ layers:
     manifest_item = next(i for i in report["inventory"] if i["id"] == "layer-manifest")
     assert manifest_item["reversible"] is False
     written = yaml.safe_load(target.read_text())
-    products = {layer["product"] for layer in written["layers"]}
-    assert products == {"cli", "claude", "codex"}
+    cli = next(
+        layer for layer in written["layers"] if layer["id"] == "cli-organization"
+    )
+    assert cli["component"] == "cli"
+    assert "product" not in cli
+    products = {layer["product"] for layer in written["layers"] if "product" in layer}
+    assert products == {"claude", "codex"}
     assert report["result"] == "ready"
+    _assert_valid_onboard_report(report)
+
+
+def test_candidate_consumer_rejection_blocks_before_any_apply(tmp_path):
+    target = tmp_path / "layers.yml"
+    target.write_text(
+        """version: 1
+layers:
+  - id: cli-organization
+    role: organization
+    component: cli
+    rank: 30
+    source: {repo: git@github-work:Acme/cli-copilot-internal.git, ref: main}
+    auth: ssh-work
+""",
+        encoding="utf-8",
+    )
+    before = target.read_bytes()
+    apply_calls = []
+
+    def personal(*, apply, **_kwargs):
+        apply_calls.append(apply)
+        return _personal()
+
+    report = build_ecosystem_onboard_report(
+        org="Acme",
+        apply=True,
+        run=_aggregate_run,
+        manifest_path=target,
+        personal_fn=personal,
+        ssh_fn=_ssh,
+        codex_fn=_codex,
+        consumer_probe_fn=lambda *_: {
+            "result": "blocked",
+            "detail": "The installed reader would lose Discord.",
+        },
+    )
+
+    assert report["result"] == "blocked"
+    assert apply_calls == [False]
+    assert target.read_bytes() == before
+    assert not (tmp_path / ".copilot-control-tower-backups").exists()
+    manifest_stage = next(s for s in report["stages"] if s["stage"] == "layer-manifest")
+    assert manifest_stage["result"] == "blocked"
+    assert "lose Discord" in manifest_stage["detail"]
+    _assert_valid_onboard_report(report)
+
+
+def test_cli_candidate_probe_rejects_capability_loss(tmp_path, monkeypatch):
+    baseline = tmp_path / "before.yml"
+    baseline.write_text("version: 1\nlayers: []\n", encoding="utf-8")
+    candidate = tmp_path / "candidate.yml"
+    candidate.write_text(
+        """version: 1
+layers:
+  - id: cli-organization
+    role: organization
+    product: cli
+    rank: 30
+    source: {repo: git@github-work:Acme/cli-copilot-internal.git, ref: main}
+    auth: work
+    activation: always
+""",
+        encoding="utf-8",
+    )
+
+    def payload(path):
+        services = [
+            {"name": "git", "tier": "foundation", "mode": "base"},
+            {"name": "discord", "tier": "foundation", "mode": "base"},
+        ]
+        if path == baseline:
+            services[-1] = {
+                "name": "discord",
+                "tier": "organization",
+                "mode": "provides",
+            }
+        return (
+            {
+                "chain": [
+                    {
+                        "id": "cli-organization",
+                        "role": "organization",
+                        "rank": 30,
+                        "repo": "git@github-work:Acme/cli-copilot-internal.git",
+                        "ref": "main",
+                        "auth": "work",
+                        "unit": None,
+                    }
+                ],
+                "services": services,
+            },
+            "",
+        )
+
+    monkeypatch.setattr(onboard_module, "_copilot_layers_payload", payload)
+
+    result = onboard_module._probe_cli_candidate(candidate, baseline)
+
+    assert result["result"] == "blocked"
+    assert "discord" in result["detail"]
+
+
+def test_materialize_failure_restores_exact_manifest_and_rematerializes_prior(
+    tmp_path,
+):
+    target = tmp_path / "layers.yml"
+    target.write_text(
+        """version: 1
+layers:
+  - id: cli-organization
+    role: organization
+    component: cli
+    rank: 30
+    source: {repo: git@github-work:Acme/cli-copilot-internal.git, ref: main}
+    auth: ssh-work
+""",
+        encoding="utf-8",
+    )
+    before = target.read_bytes()
+    updates = []
+
+    def update(**kwargs):
+        updates.append(Path(kwargs["_manifest_path"]).read_bytes())
+        if len(updates) == 1:
+            return {"result": "blocked", "blocked": [{}], "held_for_approval": []}, 2
+        return {"result": "up-to-date", "blocked": [], "held_for_approval": []}, 0
+
+    report = build_ecosystem_onboard_report(
+        org="Acme",
+        apply=True,
+        run=_aggregate_run,
+        manifest_path=target,
+        personal_fn=_personal,
+        ssh_fn=_ssh,
+        codex_fn=_codex,
+        consumer_probe_fn=_consumer_ready,
+        update_fn=update,
+        doctor_fn=lambda **_: pytest.fail("doctor must not run after update failure"),
+    )
+
+    assert report["result"] == "blocked"
+    assert len(updates) == 2
+    assert updates[0] != before
+    assert updates[1] == before
+    assert target.read_bytes() == before
+    manifest_stage = next(s for s in report["stages"] if s["stage"] == "layer-manifest")
+    assert manifest_stage["result"] == "rolled-back"
+    assert Path(manifest_stage["rollback_path"]).read_bytes() == before
+    _assert_valid_onboard_report(report)
+
+
+def test_unhealthy_post_apply_doctor_restores_exact_manifest(tmp_path):
+    target = tmp_path / "layers.yml"
+    target.write_text(
+        """version: 1
+layers:
+  - id: cli-organization
+    role: organization
+    component: cli
+    rank: 30
+    source: {repo: git@github-work:Acme/cli-copilot-internal.git, ref: main}
+    auth: ssh-work
+""",
+        encoding="utf-8",
+    )
+    before = target.read_bytes()
+    updates = []
+
+    def update(**kwargs):
+        updates.append(Path(kwargs["_manifest_path"]).read_bytes())
+        return {"result": "up-to-date", "blocked": [], "held_for_approval": []}, 0
+
+    report = build_ecosystem_onboard_report(
+        org="Acme",
+        apply=True,
+        run=_aggregate_run,
+        manifest_path=target,
+        personal_fn=_personal,
+        ssh_fn=_ssh,
+        codex_fn=_codex,
+        consumer_probe_fn=_consumer_ready,
+        update_fn=update,
+        doctor_fn=lambda **_: {"status": "unhealthy", "score": 20},
+    )
+
+    assert report["result"] == "blocked"
+    assert len(updates) == 2
+    assert updates[1] == before
+    assert target.read_bytes() == before
+    manifest_stage = next(s for s in report["stages"] if s["stage"] == "layer-manifest")
+    assert manifest_stage["result"] == "rolled-back"
     _assert_valid_onboard_report(report)
 
 
@@ -758,6 +967,7 @@ def test_unfamiliar_manifest_blocks_before_personal_apply(tmp_path):
         personal_fn=personal,
         ssh_fn=_ssh,
         codex_fn=_codex,
+        consumer_probe_fn=_consumer_ready,
     )
 
     assert report["result"] == "blocked"
@@ -855,11 +1065,12 @@ def test_ecosystem_apply_writes_exact_refs_and_runs_update_doctor(
         personal_fn=_personal,
         ssh_fn=_ssh,
         codex_fn=_codex,
+        consumer_probe_fn=_consumer_ready,
         update_fn=lambda **_: (
             {"result": "up-to-date", "blocked": [], "held_for_approval": []},
             0,
         ),
-        doctor_fn=lambda: {"status": "healthy", "score": 100},
+        doctor_fn=lambda **_: {"status": "healthy", "score": 100},
     )
     assert report["result"] == "ready"
     manifest = yaml.safe_load((tmp_path / "layers.yml").read_text())
@@ -915,6 +1126,7 @@ def test_connected_store_without_scope_identifiers_blocks_before_writes(tmp_path
         personal_fn=_personal,
         ssh_fn=_ssh,
         codex_fn=_codex,
+        consumer_probe_fn=_consumer_ready,
     )
     assert report["result"] == "blocked"
     assert report["stages"][-1]["stage"] == "secret-store"
@@ -998,11 +1210,12 @@ def test_unavailable_optional_store_does_not_block_core_apply(tmp_path):
             "detail": "Shared integrations were left for later.",
         },
         codex_fn=_codex,
+        consumer_probe_fn=_consumer_ready,
         update_fn=lambda **_: (
             {"result": "up-to-date", "blocked": [], "held_for_approval": []},
             0,
         ),
-        doctor_fn=lambda: {"status": "healthy", "score": 100},
+        doctor_fn=lambda **_: {"status": "healthy", "score": 100},
     )
 
     assert report["result"] == "ready"
@@ -1070,6 +1283,7 @@ def test_aggregate_block_before_manifest_still_returns_layers_field(tmp_path):
         },
         ssh_fn=_ssh,
         codex_fn=_codex,
+        consumer_probe_fn=_consumer_ready,
     )
     assert report["result"] == "blocked"
     assert report["layers"] == []

--- a/tools/cc/uv.lock
+++ b/tools/cc/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "claude-cli"
-version = "1.7.8"
+version = "1.7.9"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
P0 writer remediation for the Control Tower schema-mismatch incident.

- preserves unrequested product mappings instead of canonicalizing them
- lets cc read legacy `component` layers during rolling migration
- stages every candidate before live replacement
- proves the installed CLI resolves the exact chain and unchanged service provenance
- blocks before apply on any capability loss
- restores exact prior manifest bytes and rematerializes the prior state after update, Codex, doctor, or config-commit failure
- bumps cc to 1.7.9

Evidence on commit 5b282a7:
- complete `tools/cc/tests` suite passes
- focused lint/format/diff checks pass
- clean wheel install reports cc 1.7.9
- wheel SHA-256: c9b9113873584a1952ed1b99459e53898a0457ad5e182fd3e0370b8c88d66536

Control Tower 1.7.8 remains quarantined. This PR does not authorize a replacement app until packaged cross-version gates pass.