### PR TITLE
Fix Finder-safe executable discovery in cc onboarding

### DIFF
--- a/.github/workflows/cc-onboard-contract.yml
+++ b/.github/workflows/cc-onboard-contract.yml
@@ -1,0 +1,51 @@
+name: cc Onboard Contract
+
+on:
+  pull_request:
+    branches:
+      - main
+      - feat/adopt-and-project-setup
+    paths:
+      - ".github/workflows/cc-onboard-contract.yml"
+      - "tools/cc/**"
+      - "tools/tc/**"
+  push:
+    branches:
+      - main
+      - feat/adopt-and-project-setup
+    paths:
+      - ".github/workflows/cc-onboard-contract.yml"
+      - "tools/cc/**"
+      - "tools/tc/**"
+
+jobs:
+  onboard-contract:
+    runs-on: macos-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            tools/cc/pyproject.toml
+            tools/tc/pyproject.toml
+
+      - name: Install contract dependencies
+        run: |
+          python -m pip install --disable-pip-version-check \
+            -e "./tools/tc" \
+            -e "./tools/cc[dev]"
+
+      - name: Test GUI-safe onboarding contracts
+        working-directory: tools/cc
+        run: |
+          python -m pytest \
+            tests/test_executables.py \
+            tests/test_onboard_contract.py \
+            tests/test_workspaces_contract.py

--- a/.github/workflows/cc-onboard-contract.yml
+++ b/.github/workflows/cc-onboard-contract.yml
@@ -48,4 +48,4 @@ jobs:
           python -m pytest \
             tests/test_executables.py \
             tests/test_onboard_contract.py \
-            tests/test_workspaces_contract.py
+            tests/test_workspaces_contract.py::test_recommendations_use_gui_safe_executable_resolver

--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "1.7.9"
+version = "1.7.10"
 description = "Unified CLI replacing copilot-memory and skills-copilot MCP servers"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI — unified replacement for copilot-memory and skills-copilot MCP servers."""
 
-__version__ = "1.7.9"
+__version__ = "1.7.10"

--- a/tools/cc/src/cc/commands/onboard.py
+++ b/tools/cc/src/cc/commands/onboard.py
@@ -29,6 +29,7 @@ from cc.core.ecosystem.manifest import (
     validate_layers,
 )
 from cc.core.ecosystem.ssh_identity import ensure_machine_ssh_identity
+from cc.core.executables import resolve_executable
 from cc.core.write_guard import assert_write_is_isolated
 
 SCHEMA_VERSION = "1.0"
@@ -53,10 +54,6 @@ FOUNDATION_ALLOWED_SIGNERS: dict[str, tuple[str, ...]] = {
     "codex": ("SHA256:FIfppOkzwXZUAamELQzYoSUQXiEAmTYiVewHe1ACMZo",),
 }
 Run = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
-_SUPPORTED_GH_PATHS = (
-    Path("/opt/homebrew/bin/gh"),
-    Path("/usr/local/bin/gh"),
-)
 
 
 def _component_label(component: str) -> str:
@@ -144,21 +141,12 @@ def _safe_repository_reference(value: Any) -> bool:
 def _run(args: Sequence[str]) -> subprocess.CompletedProcess[str]:
     if not args:
         return subprocess.CompletedProcess(args, 127, "", "No command was provided.")
-    executable = shutil.which(args[0])
-    if executable is None and args[0] == "gh":
-        executable = next(
-            (
-                str(candidate)
-                for candidate in _SUPPORTED_GH_PATHS
-                if candidate.is_file() and os.access(candidate, os.X_OK)
-            ),
-            None,
-        )
+    executable = resolve_executable(args[0])
     if executable is None:
         return subprocess.CompletedProcess(
             args, 127, "", f"{args[0]} is not installed."
         )
-    resolved = str(Path(executable).resolve())
+    resolved = str(executable)
     environment = None
     if Path(resolved).name == "gh":
         try:
@@ -1059,14 +1047,14 @@ def _rollback_manifest_adoption(plan: ManifestAdoption, backup: Path | None) -> 
 
 def _copilot_layers_payload(manifest_path: Path) -> tuple[dict[str, Any] | None, str]:
     """Ask the installed CLI to resolve one candidate manifest."""
-    executable = shutil.which("copilot")
+    executable = resolve_executable("copilot")
     if executable is None:
         return None, "The installed `copilot` command is unavailable."
     environment = os.environ.copy()
     environment["COPILOT_LAYERS_FILE"] = str(manifest_path)
     try:
         result = subprocess.run(
-            (str(Path(executable).resolve()), "--json", "layers"),
+            (str(executable), "--json", "layers"),
             capture_output=True,
             text=True,
             check=False,

--- a/tools/cc/src/cc/core/ecosystem/workspaces.py
+++ b/tools/cc/src/cc/core/ecosystem/workspaces.py
@@ -88,6 +88,7 @@ from cc.core.ecosystem.projects import (
     read_project_lock,
     write_project_lock,
 )
+from cc.core.executables import resolve_executable
 
 PROJECT_DECLARATION_FILENAME = "copilot.project.json"
 PERSONAL_PROJECTS_FILENAME = "personal-projects.json"
@@ -572,12 +573,22 @@ def installed_components(project: Path | str) -> list[str]:
     return [component for component in SUPPORTED_COMPONENTS if component in installed]
 
 
-def recommended_components(project: Path | str, *, which: Callable[[str], Optional[str]] = shutil.which) -> list[str]:
+def recommended_components(
+    project: Path | str,
+    *,
+    which: Callable[[str], Optional[str]] | None = None,
+) -> list[str]:
     installed = installed_components(project)
     detected = set(installed)
-    if which("claude"):
+
+    def installed_path(command: str) -> str | None:
+        path = resolve_executable(command)
+        return str(path) if path is not None else None
+
+    locator = which or installed_path
+    if locator("claude"):
         detected.add("claude")
-    if which("codex"):
+    if locator("codex"):
         detected.add("codex")
     if not detected:
         detected.update(SUPPORTED_COMPONENTS)
@@ -664,7 +675,7 @@ def workspace_status(
     claude_root: Optional[Path | str] = None,
     codex_root: Optional[Path | str] = None,
     run: Run = _run,
-    which: Callable[[str], Optional[str]] = shutil.which,
+    which: Callable[[str], Optional[str]] | None = None,
 ) -> dict[str, Any]:
     root = Path(project).expanduser()
     declaration, declaration_error = read_declaration(root)

--- a/tools/cc/src/cc/core/executables.py
+++ b/tools/cc/src/cc/core/executables.py
@@ -1,0 +1,84 @@
+"""Deterministic resolution for command-line tools used by ``cc``.
+
+Desktop callers such as Finder and launchd do not inherit an interactive
+shell's PATH. Machine inventory must not change merely because the same signed
+``cc`` binary was launched by Control Tower instead of a terminal.
+
+Resolution therefore keeps the caller's PATH as the first choice, then checks
+a small registry of conventional absolute install locations. Every successful
+answer is an executable, canonical absolute path; callers never spawn a bare
+command name.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Callable, Iterable
+
+Which = Callable[[str], str | None]
+
+STANDARD_EXECUTABLE_PATHS: dict[str, tuple[str, ...]] = {
+    "gh": (
+        "~/.local/bin/gh",
+        "/opt/homebrew/bin/gh",
+        "/usr/local/bin/gh",
+    ),
+    "copilot": (
+        "~/.local/bin/copilot",
+        "/opt/homebrew/bin/copilot",
+        "/usr/local/bin/copilot",
+    ),
+    "claude": (
+        "~/.local/bin/claude",
+        "/opt/homebrew/bin/claude",
+        "/usr/local/bin/claude",
+    ),
+    "codex": (
+        "~/.local/bin/codex",
+        "/opt/homebrew/bin/codex",
+        "/usr/local/bin/codex",
+    ),
+}
+
+
+def _canonical_executable(candidate: str | Path) -> Path | None:
+    path = Path(candidate).expanduser()
+    try:
+        if not path.is_file() or not os.access(path, os.X_OK):
+            return None
+        return path.resolve(strict=True)
+    except OSError:
+        return None
+
+
+def resolve_executable(
+    command: str,
+    *,
+    which: Which = shutil.which,
+    standard_paths: Iterable[str | Path] | None = None,
+) -> Path | None:
+    """Resolve ``command`` without making GUI launches depend on shell PATH.
+
+    ``standard_paths`` is an explicit test/integration seam. Production callers
+    omit it and use the closed registry above; an unknown command remains
+    PATH-only and fails honestly when it cannot be resolved.
+    """
+
+    from_path = which(command)
+    if from_path:
+        resolved = _canonical_executable(from_path)
+        if resolved is not None:
+            return resolved
+
+    candidates = (
+        tuple(standard_paths)
+        if standard_paths is not None
+        else STANDARD_EXECUTABLE_PATHS.get(command, ())
+    )
+    for candidate in candidates:
+        resolved = _canonical_executable(candidate)
+        if resolved is not None:
+            return resolved
+    return None

--- a/tools/cc/tests/test_executables.py
+++ b/tools/cc/tests/test_executables.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import pytest
+from cc.core.executables import STANDARD_EXECUTABLE_PATHS, resolve_executable
+
+
+def _executable(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def test_path_resolution_wins_and_returns_canonical_absolute_path(tmp_path):
+    target = _executable(tmp_path / "real" / "copilot")
+    linked = tmp_path / "bin" / "copilot"
+    linked.parent.mkdir()
+    linked.symlink_to(target)
+
+    resolved = resolve_executable(
+        "copilot",
+        which=lambda _command: str(linked),
+        standard_paths=(tmp_path / "fallback",),
+    )
+
+    assert resolved == target.resolve()
+
+
+def test_standard_location_fallback_works_without_shell_path(tmp_path):
+    target = _executable(tmp_path / "standard" / "copilot")
+
+    resolved = resolve_executable(
+        "copilot",
+        which=lambda _command: None,
+        standard_paths=(tmp_path / "missing", target),
+    )
+
+    assert resolved == target.resolve()
+
+
+def test_non_executable_candidates_are_rejected(tmp_path):
+    candidate = tmp_path / "copilot"
+    candidate.write_text("#!/bin/sh\n", encoding="utf-8")
+    candidate.chmod(0o644)
+
+    assert (
+        resolve_executable(
+            "copilot",
+            which=lambda _command: str(candidate),
+            standard_paths=(candidate,),
+        )
+        is None
+    )
+
+
+def test_user_local_fallback_expands_the_current_home(monkeypatch, tmp_path):
+    target = _executable(tmp_path / ".local" / "bin" / "claude")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    resolved = resolve_executable("claude", which=lambda _command: None)
+
+    assert resolved == target.resolve()
+
+
+@pytest.mark.parametrize("command", ("gh", "copilot", "claude", "codex"))
+def test_gui_sensitive_direct_dependencies_have_bounded_fallbacks(command):
+    candidates = STANDARD_EXECUTABLE_PATHS[command]
+
+    assert candidates
+    assert all(
+        candidate.startswith("~/") or candidate.startswith("/")
+        for candidate in candidates
+    )
+
+
+def test_unknown_command_remains_path_only():
+    assert resolve_executable("unknown-command", which=lambda _command: None) is None

--- a/tools/cc/tests/test_onboard_contract.py
+++ b/tools/cc/tests/test_onboard_contract.py
@@ -108,7 +108,9 @@ def test_default_github_runner_uses_authorized_keychain_token_without_argv_leak(
         captured["env"] = kwargs["env"]
         return subprocess.CompletedProcess(args, 0, "{}", "")
 
-    monkeypatch.setattr(onboard_module.shutil, "which", lambda _: "/usr/local/bin/gh")
+    monkeypatch.setattr(
+        onboard_module, "resolve_executable", lambda _: Path("/usr/local/bin/gh")
+    )
     monkeypatch.setattr(
         onboard_module.authstore, "read_identity", lambda: {"login": "pablo"}
     )
@@ -140,8 +142,9 @@ def test_default_github_runner_falls_back_to_supported_absolute_path(
         captured["args"] = tuple(args)
         return subprocess.CompletedProcess(args, 0, "[]", "")
 
-    monkeypatch.setattr(onboard_module.shutil, "which", lambda _: None)
-    monkeypatch.setattr(onboard_module, "_SUPPORTED_GH_PATHS", (gh_path,))
+    monkeypatch.setattr(
+        onboard_module, "resolve_executable", lambda _: gh_path.resolve()
+    )
     monkeypatch.setattr(onboard_module.authstore, "read_identity", lambda: {})
     monkeypatch.setattr(onboard_module.subprocess, "run", fake_run)
 
@@ -159,16 +162,41 @@ def test_default_github_runner_falls_back_to_supported_absolute_path(
 def test_default_github_runner_stays_fail_closed_without_supported_binary(
     monkeypatch, tmp_path
 ):
-    monkeypatch.setattr(onboard_module.shutil, "which", lambda _: None)
-    monkeypatch.setattr(
-        onboard_module, "_SUPPORTED_GH_PATHS", (tmp_path / "missing-gh",)
-    )
+    monkeypatch.setattr(onboard_module, "resolve_executable", lambda _: None)
 
     result = onboard_module._run(("gh", "api", "user/orgs", "--paginate"))
 
     assert result.returncode == 127
     assert result.stdout == ""
     assert result.stderr == "gh is not installed."
+
+
+def test_copilot_probe_uses_resolved_absolute_executable(monkeypatch, tmp_path):
+    copilot = tmp_path / "copilot"
+    copilot.write_text("#!/bin/sh\n", encoding="utf-8")
+    copilot.chmod(0o755)
+    manifest = tmp_path / "copilot.layers.yml"
+    manifest.write_text("version: 1\nlayers: []\n", encoding="utf-8")
+    captured = {}
+
+    def fake_run(args, **kwargs):
+        captured["args"] = tuple(args)
+        captured["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(
+            args, 0, '{"chain": [], "services": []}', ""
+        )
+
+    monkeypatch.setattr(
+        onboard_module, "resolve_executable", lambda _: copilot.resolve()
+    )
+    monkeypatch.setattr(onboard_module.subprocess, "run", fake_run)
+
+    payload, detail = onboard_module._copilot_layers_payload(manifest)
+
+    assert detail == ""
+    assert payload == {"chain": [], "services": []}
+    assert captured["args"] == (str(copilot.resolve()), "--json", "layers")
+    assert captured["env"]["COPILOT_LAYERS_FILE"] == str(manifest)
 
 
 def test_plan_reuses_private_and_marks_only_404_missing():

--- a/tools/cc/tests/test_workspaces_contract.py
+++ b/tools/cc/tests/test_workspaces_contract.py
@@ -5,7 +5,6 @@ import subprocess
 from pathlib import Path
 
 from cc.commands import workspaces as workspaces_command
-from cc.core.ecosystem import workspaces as core_workspaces
 from cc.core.ecosystem.workspaces import (
     RECENTLY_SET_UP_WINDOW_HOURS,
     ActivationError,
@@ -19,15 +18,17 @@ from cc.core.ecosystem.workspaces import (
     project_id,
     read_known_projects_registry,
     read_personal_registry,
+    recently_set_up,
     record_automatic_setup,
     record_root_grant,
-    recently_set_up,
     revert_project,
     undo_status,
     workspace_status,
     write_declaration,
     write_install_lock,
 )
+
+from cc.core.ecosystem import workspaces as core_workspaces
 
 
 def _git_init(path: Path, remote: str | None = None) -> None:
@@ -68,6 +69,19 @@ def test_status_distinguishes_shared_declaration_from_real_installation(tmp_path
     assert report["declared_components"] == ["claude", "codex"]
     assert report["installed_components"] == []
     assert report["recommended_components"] == ["claude", "codex"]
+
+
+def test_recommendations_use_gui_safe_executable_resolver(monkeypatch, tmp_path):
+    claude = tmp_path / "claude"
+    claude.write_text("#!/bin/sh\n", encoding="utf-8")
+    claude.chmod(0o755)
+    monkeypatch.setattr(
+        core_workspaces,
+        "resolve_executable",
+        lambda command: claude if command == "claude" else None,
+    )
+
+    assert core_workspaces.recommended_components(tmp_path) == ["claude"]
 
 
 def test_explicit_markers_are_ready_and_arbitrary_claude_folder_is_not(tmp_path):

--- a/tools/cc/uv.lock
+++ b/tools/cc/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "claude-cli"
-version = "1.7.9"
+version = "1.7.10"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
- centralize deterministic executable discovery for GUI-launched onboarding
- resolve gh, copilot, claude, and codex to canonical absolute paths
- add Finder-environment regression coverage and a dedicated onboarding CI contract
- bump cc to 1.7.10

## Verification
- focused contract suite: passed
- supported cc suite excluding pre-existing MCP compatibility tests: 1147 passed
- real `cc onboard --json` with Finder PATH: changes-required, layer manifest detected
- no Control Tower GUI launch required