### PR TITLE
Gate setup on live managed-store verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **GitHub-authorized read-only store verification (`cc` 2.12.0):** `cc store
+  verify --json` validates the protected ecosystem scope and delegates live
+  positive-read and negative-denial checks to CLI Copilot without returning
+  secret names or values. The Python-owned setup journey now requires this
+  store proof before it can report `operational: true` at `confidence: 0.95`.
+  `cc support latest --json` also returns the newest private, redacted setup
+  report in a paste-ready envelope after verifying its type, owner, mode, and
+  schema.
+
 - **Python-owned end-to-end setup (`cc` 2.11.0):** `cc reconcile run --json`
   now owns the complete machine-to-project journey: recover interrupted work,
   checkpoint dirty Product projects locally without pushing, refresh shared

--- a/VERSION.json
+++ b/VERSION.json
@@ -3,10 +3,10 @@
   "lastUpdated": "2026-08-07T00:00:00.000Z",
   "components": {
     "cc": {
-      "version": "2.11.1",
+      "version": "2.12.0",
       "path": "tools/cc",
       "installScript": "tools/cc/install.sh",
-      "provides": ["cc memory", "cc memory check", "cc skill", "cc config", "cc env", "cc docs", "cc usage", "cc eval", "cc reconcile"]
+      "provides": ["cc memory", "cc memory check", "cc skill", "cc config", "cc env", "cc docs", "cc usage", "cc eval", "cc reconcile", "cc store", "cc support"]
     },
     "tc": {
       "version": "1.3.0",

--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "2.11.1"
+version = "2.12.0"
 description = "Unified CLI replacing copilot-memory and skills-copilot MCP servers"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI — unified replacement for copilot-memory and skills-copilot MCP servers."""
 
-__version__ = "2.11.1"
+__version__ = "2.12.0"

--- a/tools/cc/src/cc/commands/store.py
+++ b/tools/cc/src/cc/commands/store.py
@@ -1,0 +1,242 @@
+"""`cc store verify` — prove the interactive GitHub-to-Infisical path."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any, Callable, Optional, Sequence
+
+import typer
+
+from cc.core.ecosystem.ecosystem_config import load_ecosystem_config
+from cc.core.executables import resolve_executable
+
+SCHEMA_VERSION = "1.0"
+Run = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+store_app = typer.Typer(help="Verify shared-store access.", no_args_is_help=True)
+
+
+def _run(args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    executable = resolve_executable(args[0]) if args else None
+    if executable is None:
+        return subprocess.CompletedProcess(args, 127, "", "copilot is not installed")
+    try:
+        return subprocess.run(
+            (str(executable), *args[1:]),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return subprocess.CompletedProcess(
+            args, 127, "", "verification process unavailable"
+        )
+
+
+def _report(
+    *,
+    result: str,
+    detail: str,
+    organization: Optional[str],
+    scope: Optional[str],
+    checks: dict[str, bool],
+    evidence: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "result": result,
+        "detail": detail,
+        "organization": organization,
+        "scope": scope,
+        "checks": checks,
+        "evidence": evidence,
+    }
+
+
+def _policy_scope(
+    cfg: dict[str, Any], scope: str
+) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+    store = cfg.get("store") if isinstance(cfg.get("store"), dict) else {}
+    if store.get("status") != "connected" or store.get("type") != "infisical":
+        return None, "The organization has not connected an Infisical store."
+    required = (
+        "endpoint",
+        "workspace_id",
+        "environment",
+        "broker_url",
+        "broker_issuer",
+        "broker_audience",
+    )
+    missing = [
+        key
+        for key in required
+        if not isinstance(store.get(key), str) or not store.get(key)
+    ]
+    if missing:
+        return (
+            None,
+            "The organization must publish the GitHub-authorized store fields: "
+            + ", ".join(missing)
+            + ".",
+        )
+    if store["broker_url"].rstrip("/") != store["broker_issuer"].rstrip("/"):
+        return None, "The organization's broker URL and issuer do not match."
+    if store["endpoint"].rstrip("/") != store["broker_audience"].rstrip("/"):
+        return (
+            None,
+            "The organization's store endpoint and broker audience do not match.",
+        )
+    rows = store.get("team_scopes")
+    if not isinstance(rows, list):
+        return (
+            None,
+            "The organization must publish a bounded read-only shared-store scope.",
+        )
+    matched = [
+        row for row in rows if isinstance(row, dict) and row.get("scope") == scope
+    ]
+    if len(matched) != 1:
+        return None, f"The organization does not declare exactly one '{scope}' scope."
+    row = matched[0]
+    path = row.get("secret_path")
+    access = row.get("access")
+    identity_id = row.get("identity_id")
+    workspace = row.get("workspace_id", store.get("workspace_id"))
+    environment = row.get("environment", store.get("environment"))
+    if (
+        access != "read"
+        or not isinstance(path, str)
+        or not path.startswith("/")
+        or path.rstrip("/") in {"", "/"}
+        or any(mark in path for mark in "*?[]{}")
+        or not isinstance(identity_id, str)
+        or not identity_id
+        or not isinstance(workspace, str)
+        or not workspace
+        or not isinstance(environment, str)
+        or not environment
+    ):
+        return (
+            None,
+            f"The organization's '{scope}' scope is not a bounded read-only scope.",
+        )
+    return row, None
+
+
+def build_store_verify_report(
+    *,
+    scope: str = "shared",
+    run: Optional[Run] = None,
+    ecosystem_cfg: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    run = run or _run
+    cfg = ecosystem_cfg if ecosystem_cfg is not None else load_ecosystem_config()
+    organization = cfg.get("org") if isinstance(cfg.get("org"), str) else None
+    checks = {
+        "policy_valid": False,
+        "positive_read": False,
+        "negative_denied": False,
+        "read_only": False,
+    }
+    row, error = _policy_scope(cfg, scope)
+    if row is None:
+        return _report(
+            result="not-configured",
+            detail=error or "The shared-store policy is unavailable.",
+            organization=organization,
+            scope=scope,
+            checks=checks,
+        )
+    checks["policy_valid"] = True
+    store = cfg["store"]
+    workspace = row.get("workspace_id") or store["workspace_id"]
+    environment = row.get("environment") or store["environment"]
+    path = row["secret_path"]
+    result = run(
+        (
+            "copilot",
+            "infisical",
+            "--json",
+            "access",
+            "verify",
+            "--project",
+            workspace,
+            "--env",
+            environment,
+            "--path",
+            path,
+            "--negative-path",
+            "/__control_tower_denied__",
+            "--scope",
+            scope,
+        )
+    )
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        payload = None
+    if not isinstance(payload, dict):
+        return _report(
+            result="unavailable",
+            detail="The Python store verifier returned an unreadable report.",
+            organization=organization,
+            scope=scope,
+            checks=checks,
+            evidence={
+                "auth_mode": None,
+                "secret_count": None,
+                "exit_code": result.returncode,
+            },
+        )
+    for name in ("positive_read", "negative_denied", "read_only"):
+        checks[name] = payload.get(name) is True
+    ready = (
+        result.returncode == 0
+        and payload.get("result") == "ready"
+        and all(checks.values())
+    )
+    reported_result = payload.get("result")
+    safe_result = (
+        reported_result
+        if reported_result in {"not-configured", "unavailable", "unsafe", "invalid-config"}
+        else "unavailable"
+    )
+    return _report(
+        result="ready" if ready else safe_result,
+        detail=(
+            "The ecosystem's shared access path is operational and read-only."
+            if ready
+            else str(payload.get("detail") or "The shared access path is unavailable.")
+        ),
+        organization=organization,
+        scope=scope,
+        checks=checks,
+        evidence={
+            "auth_mode": payload.get("auth_mode"),
+            "secret_count": payload.get("secret_count"),
+            "exit_code": result.returncode,
+        },
+    )
+
+
+def render_store_verify_report(report: dict[str, Any]) -> None:
+    from rich.console import Console
+
+    console = Console()
+    color = "green" if report.get("result") == "ready" else "yellow"
+    console.print(f"[{color}]{report.get('detail')}[/{color}]")
+
+
+@store_app.command("verify")
+def store_verify_cmd(
+    scope: str = typer.Option("shared", "--scope", help="Store scope to verify."),
+    output_json: bool = typer.Option(False, "--json", help="Output JSON."),
+) -> None:
+    report = build_store_verify_report(scope=scope)
+    if output_json:
+        typer.echo(json.dumps(report))
+    else:
+        render_store_verify_report(report)
+    raise typer.Exit(0 if report.get("result") == "ready" else 1)

--- a/tools/cc/src/cc/commands/support.py
+++ b/tools/cc/src/cc/commands/support.py
@@ -1,0 +1,88 @@
+"""Read the newest private, redacted Control Tower support report."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import typer
+
+from cc.core.config_paths import machine_diagnostics_root
+
+support_app = typer.Typer(
+    help="Access redacted setup support reports.", no_args_is_help=True
+)
+
+
+def _latest_record(
+    *, root: Optional[Path] = None
+) -> tuple[Optional[Path], Optional[dict]]:
+    diagnostics_root = (root or machine_diagnostics_root()).expanduser()
+    directory = diagnostics_root / "control-tower"
+    try:
+        candidates = sorted(
+            (
+                candidate
+                for candidate in directory.glob("setup-journey-*.json")
+                if not candidate.is_symlink() and candidate.is_file()
+            ),
+            key=lambda path: (path.stat().st_mtime_ns, path.name),
+            reverse=True,
+        )
+    except OSError:
+        return None, None
+    for path in candidates:
+        try:
+            metadata = path.stat()
+            if metadata.st_uid != os.getuid() or metadata.st_mode & 0o077:
+                continue
+            payload: Any = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if (
+            isinstance(payload, dict)
+            and payload.get("schema_version") == "1.0"
+            and payload.get("kind") == "setup-journey-support-report"
+        ):
+            return path, payload
+    return None, None
+
+
+def build_support_latest_report(*, root: Optional[Path] = None) -> dict[str, Any]:
+    path, record = _latest_record(root=root)
+    if path is None or record is None:
+        return {
+            "schema_version": "1.0",
+            "result": "unavailable",
+            "detail": "No private setup support report is available yet.",
+            "path": None,
+            "report": None,
+        }
+    return {
+        "schema_version": "1.0",
+        "result": "ready",
+        "detail": "The newest private, redacted setup support report is available.",
+        "path": str(path),
+        "report": record,
+    }
+
+
+@support_app.command("latest")
+def support_latest(
+    output_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Print a paste-ready JSON envelope containing the redacted report.",
+    ),
+) -> None:
+    report = build_support_latest_report()
+    if output_json:
+        typer.echo(json.dumps(report, indent=2, sort_keys=True))
+    elif report["result"] == "ready":
+        typer.echo(report["path"])
+        typer.echo(json.dumps(report["report"], indent=2, sort_keys=True))
+    else:
+        typer.echo(report["detail"], err=True)
+    raise typer.Exit(0 if report["result"] == "ready" else 1)

--- a/tools/cc/src/cc/core/ecosystem/component_status.py
+++ b/tools/cc/src/cc/core/ecosystem/component_status.py
@@ -461,7 +461,7 @@ def compute_component_checkers(
                 _visible_checkout_relation(
                     layer, local_sha=local_sha, remote_sha=remote_sha
                 )
-                if comparison_kind == "source"
+                if comparison_kind in {"source", "source-tag"}
                 else None
             )
             if relation == "ahead":

--- a/tools/cc/src/cc/core/ecosystem/component_status.py
+++ b/tools/cc/src/cc/core/ecosystem/component_status.py
@@ -38,7 +38,9 @@ Severity fold (never fabricated):
   - the repository answered but neither the pointer nor declared source ref
     exists -> `warn` without an offline signal.
   - `local_sha == remote_sha` -> `pass`.
-  - otherwise -> `warn` ("behind"), with a `repair: "cc update"` hint.
+  - otherwise -> `warn`, distinguishing a checkout that is behind, ahead with
+    authored commits, diverged, or not comparable. Only a proven behind state
+    is described as behind.
 
 This module never emits `severity: "fail"` -- a sync gap is a `warn`
 ("update-available"-flavored), not a hard failure; `doctor.py`'s status
@@ -185,6 +187,41 @@ def _visible_checkout_head_sha(layer: dict[str, Any]) -> Optional[str]:
     return sha or None
 
 
+def _visible_checkout_relation(
+    layer: dict[str, Any], *, local_sha: Optional[str], remote_sha: str
+) -> Optional[str]:
+    """Classify two locally present commit objects without fetching or writing."""
+    if not local_sha:
+        return None
+    source = layer.get("source") or {}
+    configured = source.get("path")
+    if not configured:
+        return None
+    root = Path(str(configured)).expanduser()
+    if not root.is_dir():
+        return None
+
+    for sha in (local_sha, remote_sha):
+        present = _run_git(["cat-file", "-e", f"{sha}^{{commit}}"], cwd=root)
+        if present is None or present.returncode != 0:
+            return None
+
+    remote_is_ancestor = _run_git(
+        ["merge-base", "--is-ancestor", remote_sha, local_sha], cwd=root
+    )
+    if remote_is_ancestor is None or remote_is_ancestor.returncode not in {0, 1}:
+        return None
+    if remote_is_ancestor.returncode == 0:
+        return "ahead"
+
+    local_is_ancestor = _run_git(
+        ["merge-base", "--is-ancestor", local_sha, remote_sha], cwd=root
+    )
+    if local_is_ancestor is None or local_is_ancestor.returncode not in {0, 1}:
+        return None
+    return "behind" if local_is_ancestor.returncode == 0 else "diverged"
+
+
 def _matches_foundation_release_snapshot(
     layer: dict[str, Any],
     *,
@@ -237,9 +274,7 @@ def _matches_foundation_release_snapshot(
             return False
 
     remote_type = _run_git(["cat-file", "-t", remote_sha], cwd=root)
-    parents = _run_git(
-        ["rev-list", "--parents", "-n", "1", remote_sha], cwd=root
-    )
+    parents = _run_git(["rev-list", "--parents", "-n", "1", remote_sha], cwd=root)
     head_tree = _run_git(["rev-parse", f"{local_sha}^{{tree}}"], cwd=root)
     snapshot_tree = _run_git(["rev-parse", f"{remote_sha}^{{tree}}"], cwd=root)
     results = (remote_type, parents, head_tree, snapshot_tree)
@@ -422,6 +457,37 @@ def compute_component_checkers(
                 )
             )
         else:
+            relation = (
+                _visible_checkout_relation(
+                    layer, local_sha=local_sha, remote_sha=remote_sha
+                )
+                if comparison_kind == "source"
+                else None
+            )
+            if relation == "ahead":
+                detail = (
+                    f"{product}/{layer_id}: local checkout contains the managed "
+                    "remote revision plus authored commits"
+                )
+                repair = "finish or preserve the authored work, then run cc update"
+            elif relation == "diverged":
+                detail = (
+                    f"{product}/{layer_id}: local checkout and managed remote "
+                    "have diverged"
+                )
+                repair = "review and preserve the authored work before updating"
+            elif relation == "behind":
+                detail = (
+                    f"{product}/{layer_id}: local {local_sha or 'none'} "
+                    f"behind remote {remote_sha}"
+                )
+                repair = "cc update"
+            else:
+                detail = (
+                    f"{product}/{layer_id}: local {local_sha or 'none'} does not "
+                    f"match remote {remote_sha}"
+                )
+                repair = "cc update"
             checkers.append(
                 Checker(
                     id=checker_id,
@@ -429,11 +495,8 @@ def compute_component_checkers(
                     layer=layer_id,
                     layer_role=layer_role,
                     product=product,
-                    detail=(
-                        f"{product}/{layer_id}: local {local_sha or 'none'} "
-                        f"behind remote {remote_sha}"
-                    ),
-                    repair="cc update",
+                    detail=detail,
+                    repair=repair,
                     local_sha=local_sha,
                     remote_sha=remote_sha,
                 )

--- a/tools/cc/src/cc/core/ecosystem/machine_assessment.py
+++ b/tools/cc/src/cc/core/ecosystem/machine_assessment.py
@@ -815,14 +815,14 @@ def _layer_assessment(
         for item in non_ready
     ]
     detail = f"{len(non_ready)} of {total} ecosystem layer(s) need attention."
-    item_label = "item that is" if len(non_ready) == 1 else "items that are"
+    item_label = "item" if len(non_ready) == 1 else "items"
     blocker: Blocker = {
         "code": "layers-not-ready",
         "responsible_actor": "ecosystem-owner",
         "evidence": evidence,
         "next_action": (
-            f"Update the {len(non_ready)} Copilot setup {item_label} behind, "
-            "then check again."
+            f"Resolve the {len(non_ready)} Copilot setup {item_label} needing "
+            "attention, then check again."
         ),
     }
     return (

--- a/tools/cc/src/cc/core/ecosystem/setup_journey.py
+++ b/tools/cc/src/cc/core/ecosystem/setup_journey.py
@@ -10,6 +10,7 @@ from collections.abc import Callable, Mapping
 from typing import Any
 
 from cc.commands.onboard import build_ecosystem_onboard_report
+from cc.commands.store import build_store_verify_report
 from cc.core.config import resolve_key
 from cc.core.ecosystem.reconciliation import (
     assess_reconciliation,
@@ -80,6 +81,7 @@ def build_setup_journey_report(
     recover_builder: ReportBuilder = build_recover_report,
     prepare_builder: ReportBuilder = build_setup_prepare_report,
     ecosystem_builder: Callable[..., dict[str, Any]] = build_ecosystem_onboard_report,
+    store_builder: ReportBuilder = build_store_verify_report,
     assess_builder: ReportBuilder = assess_reconciliation,
     plan_builder: Callable[..., dict[str, Any]] = build_plan_report,
     apply_builder: Callable[..., dict[str, Any]] = build_apply_report,
@@ -135,6 +137,12 @@ def build_setup_journey_report(
             ecosystem = _failure("ecosystem", exc)
     phases.append(ecosystem)
     actions.extend(ecosystem.get("completed_actions", []))
+
+    try:
+        store = {"phase": "store", **store_builder()}
+    except Exception as exc:
+        store = _failure("store", exc)
+    phases.append(store)
 
     assessment: dict[str, Any] | None = None
     for _pass in range(max_project_passes):
@@ -196,7 +204,7 @@ def _result(
     latest_required: dict[str, dict[str, Any]] = {}
     for phase in phases:
         name = phase.get("phase")
-        if name in {"recover", "prepare", "ecosystem"}:
+        if name in {"recover", "prepare", "ecosystem", "store"}:
             latest_required[str(name)] = phase
     phase_holds = [
         phase

--- a/tools/cc/src/cc/core/ecosystem/setup_journey_diagnostics.py
+++ b/tools/cc/src/cc/core/ecosystem/setup_journey_diagnostics.py
@@ -97,6 +97,7 @@ def _safe_action(value: Any) -> dict[str, Any] | None:
         "action",
         "kind",
         "status",
+        "outcome",
         "component",
         "repository",
         "path",
@@ -104,6 +105,18 @@ def _safe_action(value: Any) -> dict[str, Any] | None:
     ):
         item = _bounded_text(value.get(key), limit=4096 if key == "path" else 240)
         if item is not None:
+            safe[key] = item
+    if "path" not in safe:
+        target = _bounded_text(value.get("target"), limit=4096)
+        if target is not None:
+            safe["path"] = target
+    if "commit" not in safe:
+        commit = _bounded_text(value.get("to_sha"), limit=80)
+        if commit is not None:
+            safe["commit"] = commit
+    for key in ("pushed", "residual_work"):
+        item = value.get(key)
+        if isinstance(item, bool):
             safe[key] = item
     return safe or None
 

--- a/tools/cc/src/cc/core/ecosystem/setup_journey_diagnostics.py
+++ b/tools/cc/src/cc/core/ecosystem/setup_journey_diagnostics.py
@@ -38,10 +38,31 @@ def _safe_phase(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, Mapping):
         return None
     safe: dict[str, Any] = {}
-    for key in ("phase", "result", "run_id", "plan_id"):
+    for key in ("phase", "result", "run_id", "plan_id", "detail", "organization", "scope"):
         item = _bounded_text(value.get(key), limit=160)
         if item is not None:
             safe[key] = item
+    checks = value.get("checks")
+    if isinstance(checks, Mapping):
+        safe_checks = {
+            key: checks.get(key) is True
+            for key in ("policy_valid", "positive_read", "negative_denied", "read_only")
+            if isinstance(checks.get(key), bool)
+        }
+        if safe_checks:
+            safe["checks"] = safe_checks
+    evidence = value.get("evidence")
+    if isinstance(evidence, Mapping):
+        safe_evidence: dict[str, Any] = {}
+        auth_mode = _bounded_text(evidence.get("auth_mode"), limit=80)
+        if auth_mode is not None:
+            safe_evidence["auth_mode"] = auth_mode
+        for key in ("secret_count", "exit_code"):
+            item = evidence.get(key)
+            if isinstance(item, int) and not isinstance(item, bool):
+                safe_evidence[key] = item
+        if safe_evidence:
+            safe["evidence"] = safe_evidence
     error = value.get("error")
     if isinstance(error, Mapping):
         code = _bounded_text(error.get("code"), limit=160)

--- a/tools/cc/src/cc/core/ecosystem/setup_journey_diagnostics.py
+++ b/tools/cc/src/cc/core/ecosystem/setup_journey_diagnostics.py
@@ -38,7 +38,15 @@ def _safe_phase(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, Mapping):
         return None
     safe: dict[str, Any] = {}
-    for key in ("phase", "result", "run_id", "plan_id", "detail", "organization", "scope"):
+    for key in (
+        "phase",
+        "result",
+        "run_id",
+        "plan_id",
+        "detail",
+        "organization",
+        "scope",
+    ):
         item = _bounded_text(value.get(key), limit=160)
         if item is not None:
             safe[key] = item
@@ -154,6 +162,23 @@ def _safe_blockers(assessment: Mapping[str, Any]) -> list[dict[str, Any]]:
             item = _bounded_text(value.get(source))
             if item is not None:
                 safe[target] = item
+        evidence = value.get("evidence")
+        if isinstance(evidence, Sequence) and not isinstance(evidence, (str, bytes)):
+            safe_evidence: list[dict[str, str]] = []
+            for item in evidence[:100]:
+                if not isinstance(item, Mapping):
+                    continue
+                identifier = _bounded_text(item.get("id"), limit=160)
+                state = _bounded_text(item.get("state"), limit=80)
+                row = {
+                    key: candidate
+                    for key, candidate in (("id", identifier), ("state", state))
+                    if candidate is not None
+                }
+                if row:
+                    safe_evidence.append(row)
+            if safe_evidence:
+                safe["evidence"] = safe_evidence
         if safe:
             blockers.append(safe)
     return blockers

--- a/tools/cc/src/cc/main.py
+++ b/tools/cc/src/cc/main.py
@@ -15,6 +15,8 @@ from cc.commands.memory import memory_app
 from cc.commands.onboard import onboard_cmd
 from cc.commands.reconcile import reconcile_app
 from cc.commands.skill import skill_app
+from cc.commands.store import store_app
+from cc.commands.support import support_app
 from cc.commands.usage import usage_app
 from cc.commands.workspaces import workspaces_app
 from cc.core.config import resolve_key
@@ -37,6 +39,8 @@ app.add_typer(auth_app, name="auth")
 app.add_typer(layers_app, name="layers")
 app.add_typer(workspaces_app, name="workspace")
 app.add_typer(reconcile_app, name="reconcile")
+app.add_typer(store_app, name="store")
+app.add_typer(support_app, name="support")
 app.command("onboard")(onboard_cmd)
 
 
@@ -94,7 +98,9 @@ def resolve_cmd(
         ),
     ),
     output_json: bool = typer.Option(
-        False, "--json", help="Output JSON (the WS-A resolve contract, in --explain mode)."
+        False,
+        "--json",
+        help="Output JSON (the WS-A resolve contract, in --explain mode).",
     ),
 ) -> None:
     """Print the resolved value of a single config key, OR (with `--explain`
@@ -659,9 +665,7 @@ def deprovision_cmd(
     soft: bool = typer.Option(
         False, "--soft", help="Shorthand for --mode soft (the default)."
     ),
-    hard: bool = typer.Option(
-        False, "--hard", help="Shorthand for --mode hard."
-    ),
+    hard: bool = typer.Option(False, "--hard", help="Shorthand for --mode hard."),
 ) -> None:
     """Wipe the disposable ecosystem trees (WS-A `deprovision --json`
     contract) -- MUTATING: acquires the copilot lock, then removes every

--- a/tools/cc/tests/fixtures/schemas/store-verify.schema.json
+++ b/tools/cc/tests/fixtures/schemas/store-verify.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://control-tower.example/schemas/store-verify.schema.json",
+  "title": "Shared-store operational verification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "result", "detail", "organization", "scope", "checks", "evidence"],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "result": { "enum": ["ready", "not-configured", "unavailable", "unsafe", "invalid-config"] },
+    "detail": { "type": "string", "minLength": 1 },
+    "organization": { "type": ["string", "null"] },
+    "scope": { "type": ["string", "null"] },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_valid", "positive_read", "negative_denied", "read_only"],
+      "properties": {
+        "policy_valid": { "type": "boolean" },
+        "positive_read": { "type": "boolean" },
+        "negative_denied": { "type": "boolean" },
+        "read_only": { "type": "boolean" }
+      }
+    },
+    "evidence": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["auth_mode", "secret_count", "exit_code"],
+      "properties": {
+        "auth_mode": { "type": ["string", "null"] },
+        "secret_count": { "type": ["integer", "null"], "minimum": 0 },
+        "exit_code": { "type": "integer" }
+      }
+    }
+  }
+}

--- a/tools/cc/tests/test_component_status.py
+++ b/tools/cc/tests/test_component_status.py
@@ -415,7 +415,8 @@ def test_foundation_parentless_release_snapshot_with_different_tree_warns(tmp_pa
     checker = checkers[0]
     assert checker.remote_sha == snapshot
     assert checker.severity == "warn"
-    assert checker.repair == "cc update"
+    assert "diverged" in checker.detail
+    assert "preserve" in checker.repair
 
 
 def test_foundation_ordinary_history_tag_with_same_tree_still_warns(tmp_path):
@@ -435,6 +436,8 @@ def test_foundation_ordinary_history_tag_with_same_tree_still_warns(tmp_path):
     assert checker.remote_sha == tagged_commit
     assert checker.local_sha != checker.remote_sha
     assert checker.severity == "warn"
+    assert "authored commits" in checker.detail
+    assert "behind" not in checker.detail
 
 
 def test_falls_back_to_mirror_clone_head_when_lock_pointer_unknown(tmp_path):

--- a/tools/cc/tests/test_component_status.py
+++ b/tools/cc/tests/test_component_status.py
@@ -110,7 +110,7 @@ def test_warn_behind_when_shas_differ():
     assert checker.severity == "warn"
     assert checker.remote_sha == "def5678def5678def5678def5678def5678123"
     assert checker.repair == "cc update"
-    assert "behind remote" in checker.detail
+    assert "does not match remote" in checker.detail
     assert offline is False
 
 
@@ -209,6 +209,7 @@ def test_reachable_repo_without_lock_pointer_reports_source_checkout_behind(tmp_
     (source / "agents" / "sec.md").write_text("v2", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=source, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "v2"], cwd=source, check=True)
+    subprocess.run(["git", "fetch", "-q", "origin", "main"], cwd=checkout, check=True)
 
     layer = _layer(
         id="personal",
@@ -223,6 +224,42 @@ def test_reachable_repo_without_lock_pointer_reports_source_checkout_behind(tmp_
     assert checker.local_sha != checker.remote_sha
     assert checker.severity == "warn"
     assert checker.repair == "cc update"
+    assert "behind remote" in checker.detail
+    assert offline is False
+
+
+def test_source_checkout_with_authored_commits_is_not_called_behind(tmp_path):
+    source = _make_content_repo(tmp_path, {"agents/sec.md": "v1"})
+    managed_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=source,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    (source / "agents" / "sec.md").write_text("authored", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=source, check=True)
+    _commit(source, "authored work")
+
+    def latest_sha(_repo, ref):
+        if ref == mirror.DEFAULT_LOCK_POINTER_REF:
+            return mirror.RemoteRefProbe(reachable=True, sha=None)
+        return mirror.RemoteRefProbe(reachable=True, sha=managed_sha)
+
+    layer = _layer(
+        id="foundation",
+        role="foundation",
+        source={"repo": str(source), "ref": "main", "path": str(source)},
+    )
+    checkers, offline = compute_component_checkers(
+        [layer], lockfile={}, latest_sha_fn=latest_sha, mirror_root=None
+    )
+
+    checker = checkers[0]
+    assert checker.severity == "warn"
+    assert "authored commits" in checker.detail
+    assert "behind" not in checker.detail
+    assert "preserve" in checker.repair
     assert offline is False
 
 
@@ -329,9 +366,7 @@ def _tag_parentless_snapshot(repo: Path, tag: str = "v1.0.0") -> str:
 def test_foundation_parentless_release_snapshot_with_same_tree_passes(tmp_path):
     source = _make_content_repo(tmp_path, {"agents/sec.md": "v1"})
     snapshot = _tag_parentless_snapshot(source)
-    layer = _layer(
-        source={"repo": str(source), "ref": "v1.0.0", "path": str(source)}
-    )
+    layer = _layer(source={"repo": str(source), "ref": "v1.0.0", "path": str(source)})
 
     checkers, offline = compute_component_checkers(
         [layer], lockfile={}, latest_sha_fn=mirror.probe_remote_ref
@@ -351,9 +386,7 @@ def test_foundation_snapshot_without_local_tag_ref_still_passes(tmp_path):
     checkout = tmp_path / "visible-checkout"
     subprocess.run(["git", "clone", "-q", str(source), str(checkout)], check=True)
     subprocess.run(["git", "tag", "-d", "v1.0.0"], cwd=checkout, check=True)
-    layer = _layer(
-        source={"repo": str(source), "ref": "v1.0.0", "path": str(checkout)}
-    )
+    layer = _layer(source={"repo": str(source), "ref": "v1.0.0", "path": str(checkout)})
 
     checkers, offline = compute_component_checkers(
         [layer], lockfile={}, latest_sha_fn=mirror.probe_remote_ref
@@ -373,9 +406,7 @@ def test_foundation_parentless_release_snapshot_with_different_tree_warns(tmp_pa
     (source / "agents" / "sec.md").write_text("local divergence", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=source, check=True)
     _commit(source, "diverge")
-    layer = _layer(
-        source={"repo": str(source), "ref": "v1.0.0", "path": str(source)}
-    )
+    layer = _layer(source={"repo": str(source), "ref": "v1.0.0", "path": str(source)})
 
     checkers, _ = compute_component_checkers(
         [layer], lockfile={}, latest_sha_fn=mirror.probe_remote_ref
@@ -394,9 +425,7 @@ def test_foundation_ordinary_history_tag_with_same_tree_still_warns(tmp_path):
         ["git", "tag", "-a", "v1.0.0", "-m", "release"], cwd=source, check=True
     )
     _commit(source, "later", allow_empty=True)
-    layer = _layer(
-        source={"repo": str(source), "ref": "v1.0.0", "path": str(source)}
-    )
+    layer = _layer(source={"repo": str(source), "ref": "v1.0.0", "path": str(source)})
 
     checkers, _ = compute_component_checkers(
         [layer], lockfile={}, latest_sha_fn=mirror.probe_remote_ref

--- a/tools/cc/tests/test_setup_journey.py
+++ b/tools/cc/tests/test_setup_journey.py
@@ -14,6 +14,10 @@ def _ready_assessment() -> dict:
     }
 
 
+def _ready_store() -> dict:
+    return {"result": "ready", "checks": {"read_only": True}}
+
+
 def test_journey_claims_operational_only_after_every_phase_is_ready(
     monkeypatch,
 ) -> None:
@@ -32,6 +36,7 @@ def test_journey_claims_operational_only_after_every_phase_is_ready(
             "result": "ready",
             "completed_actions": [],
         },
+        store_builder=_ready_store,
         assess_builder=_ready_assessment,
         diagnostics_writer=lambda report: {"state": "available", "path": "/report"},
     )
@@ -75,6 +80,7 @@ def test_journey_applies_safe_defaults_then_reassesses_and_checkpoints(
             "result": "ready",
             "completed_actions": [],
         },
+        store_builder=_ready_store,
         assess_builder=lambda: next(assessments),
         plan_builder=lambda request: {
             "phase": "plan",
@@ -111,6 +117,7 @@ def test_journey_never_claims_operational_when_external_phase_is_held(
             "result": "ready",
             "completed_actions": [],
         },
+        store_builder=_ready_store,
         assess_builder=_ready_assessment,
         diagnostics_writer=lambda report: {"state": "available", "path": "/report"},
     )
@@ -147,6 +154,7 @@ def test_journey_does_not_treat_successful_prepare_with_machine_action_as_a_hold
             "result": "ready",
             "completed_actions": [],
         },
+        store_builder=_ready_store,
         assess_builder=lambda: action_required,
         diagnostics_writer=lambda report: {"state": "available", "path": "/report"},
     )
@@ -190,6 +198,7 @@ def test_journey_result_survives_diagnostic_writer_failure(monkeypatch) -> None:
             "result": "ready",
             "completed_actions": [],
         },
+        store_builder=_ready_store,
         assess_builder=_ready_assessment,
         diagnostics_writer=fail_diagnostic,
     )
@@ -197,3 +206,34 @@ def test_journey_result_survives_diagnostic_writer_failure(monkeypatch) -> None:
     assert report["operational"] is True
     assert report["diagnostics"]["state"] == "unavailable"
     assert "do-not-return-this" not in str(report)
+
+
+def test_journey_never_claims_operational_without_live_read_only_store_proof(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "cc.core.ecosystem.setup_journey.resolve_key",
+        lambda key: "Example-Org" if key == "github_app.org" else "/repos",
+    )
+    report = build_setup_journey_report(
+        recover_builder=lambda: {"phase": "recover", "result": "ready"},
+        prepare_builder=lambda: {
+            "phase": "prepare",
+            "result": "ready",
+            "completed_actions": [],
+        },
+        ecosystem_builder=lambda **kwargs: {
+            "result": "ready",
+            "completed_actions": [],
+        },
+        store_builder=lambda: {
+            "result": "unsafe",
+            "checks": {"positive_read": True, "negative_denied": False},
+        },
+        assess_builder=_ready_assessment,
+        diagnostics_writer=lambda report: {"state": "available", "path": "/report"},
+    )
+
+    assert report["operational"] is False
+    assert report["confidence"] == 0.0
+    assert any(hold.get("phase") == "store" for hold in report["holds"])

--- a/tools/cc/tests/test_setup_journey_diagnostics.py
+++ b/tools/cc/tests/test_setup_journey_diagnostics.py
@@ -51,8 +51,12 @@ def _report() -> dict:
         ],
         "completed_actions": [
             {
-                "action": "checkpoint",
-                "path": "/projects/example",
+                "kind": "project-checkpoint",
+                "target": "/projects/example",
+                "outcome": "completed",
+                "to_sha": "a" * 40,
+                "pushed": False,
+                "residual_work": False,
                 "detail": "password=must-not-survive",
             }
         ],
@@ -112,6 +116,16 @@ def test_safe_record_is_useful_and_strictly_allowlisted() -> None:
     assert record["machine"]["blockers"][0]["code"] == "connection-identity-invalid"
     assert record["machine"]["blockers"][0]["evidence"] == [
         {"id": "shared-store-auth", "state": "blocked"}
+    ]
+    assert record["completed_actions"] == [
+        {
+            "kind": "project-checkpoint",
+            "outcome": "completed",
+            "path": "/projects/example",
+            "commit": "a" * 40,
+            "pushed": False,
+            "residual_work": False,
+        }
     ]
     assert record["projects"]["scope_counts"]["product_projects"] == 47
     assert record["projects"]["holds"][0]["path"] == "/projects/held"

--- a/tools/cc/tests/test_setup_journey_diagnostics.py
+++ b/tools/cc/tests/test_setup_journey_diagnostics.py
@@ -47,7 +47,7 @@ def _report() -> dict:
                     "exit_code": 1,
                     "token": "must-not-survive",
                 },
-            }
+            },
         ],
         "completed_actions": [
             {
@@ -65,7 +65,13 @@ def _report() -> dict:
                         "code": "connection-identity-invalid",
                         "responsible_actor": "ecosystem-owner",
                         "next_action": "Restore the machine identity.",
-                        "evidence": [{"detail": "token=must-not-survive"}],
+                        "evidence": [
+                            {
+                                "id": "shared-store-auth",
+                                "state": "blocked",
+                                "detail": "token=must-not-survive",
+                            }
+                        ],
                     }
                 ],
             },
@@ -104,6 +110,9 @@ def test_safe_record_is_useful_and_strictly_allowlisted() -> None:
     rendered = json.dumps(record)
 
     assert record["machine"]["blockers"][0]["code"] == "connection-identity-invalid"
+    assert record["machine"]["blockers"][0]["evidence"] == [
+        {"id": "shared-store-auth", "state": "blocked"}
+    ]
     assert record["projects"]["scope_counts"]["product_projects"] == 47
     assert record["projects"]["holds"][0]["path"] == "/projects/held"
     assert len(record["projects"]["holds"]) == 1

--- a/tools/cc/tests/test_setup_journey_diagnostics.py
+++ b/tools/cc/tests/test_setup_journey_diagnostics.py
@@ -27,6 +27,26 @@ def _report() -> dict:
                     "state": "available",
                     "path": "/private/nested-report.json",
                 },
+            },
+            {
+                "phase": "store",
+                "result": "unavailable",
+                "detail": "The live read-only store proof did not pass.",
+                "organization": "Example-Org",
+                "scope": "shared",
+                "checks": {
+                    "policy_valid": True,
+                    "positive_read": False,
+                    "negative_denied": False,
+                    "read_only": False,
+                    "untrusted": "must-not-survive",
+                },
+                "evidence": {
+                    "auth_mode": "github-broker",
+                    "secret_count": 0,
+                    "exit_code": 1,
+                    "token": "must-not-survive",
+                },
             }
         ],
         "completed_actions": [
@@ -88,9 +108,18 @@ def test_safe_record_is_useful_and_strictly_allowlisted() -> None:
     assert record["projects"]["holds"][0]["path"] == "/projects/held"
     assert len(record["projects"]["holds"]) == 1
     assert record["nested_diagnostics"][0]["path"] == "/private/nested-report.json"
+    store = record["phases"][1]
+    assert store["detail"] == "The live read-only store proof did not pass."
+    assert store["checks"]["read_only"] is False
+    assert store["evidence"] == {
+        "auth_mode": "github-broker",
+        "secret_count": 0,
+        "exit_code": 1,
+    }
     assert "must-not-survive" not in rendered
     assert '"secret"' not in rendered
-    assert '"evidence"' not in rendered
+    assert '"token"' not in rendered
+    assert '"untrusted"' not in rendered
 
 
 def test_writer_saves_private_report_and_prunes_owned_records(tmp_path: Path) -> None:

--- a/tools/cc/tests/test_store_contract.py
+++ b/tools/cc/tests/test_store_contract.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+from cc.commands.store import build_store_verify_report
+
+
+def _config():
+    return {
+        "org": "Example-Org",
+        "store": {
+            "status": "connected",
+            "type": "infisical",
+            "endpoint": "https://secrets.example.test",
+            "workspace_id": "workspace-1",
+            "environment": "prod",
+            "secret_path": "/shared",
+            "broker_url": "https://access.example.test",
+            "broker_issuer": "https://access.example.test",
+            "broker_audience": "https://secrets.example.test",
+            "team_scopes": [
+                {
+                    "team": "everyone",
+                    "scope": "shared",
+                    "environment": "prod",
+                    "secret_path": "/shared",
+                    "access": "read",
+                    "identity_id": "identity-shared",
+                }
+            ],
+        },
+    }
+
+
+def test_store_verify_requires_positive_and_negative_live_evidence():
+    observed = []
+
+    def run(args):
+        observed.append(tuple(args))
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            json.dumps(
+                {
+                    "schema_version": "1.0",
+                    "result": "ready",
+                    "detail": "ready",
+                    "auth_mode": "github-broker",
+                    "positive_read": True,
+                    "negative_denied": True,
+                    "secret_count": 8,
+                    "read_only": True,
+                }
+            ),
+            "",
+        )
+
+    report = build_store_verify_report(run=run, ecosystem_cfg=_config())
+
+    assert report["result"] == "ready"
+    assert all(report["checks"].values())
+    assert report["evidence"] == {
+        "auth_mode": "github-broker",
+        "secret_count": 8,
+        "exit_code": 0,
+    }
+    command = observed[0]
+    assert command[:5] == ("copilot", "infisical", "--json", "access", "verify")
+    assert "--negative-path" in command
+    assert "--scope" in command
+
+
+def test_store_verify_fails_closed_when_negative_scope_is_readable():
+    def run(args):
+        return subprocess.CompletedProcess(
+            args,
+            1,
+            json.dumps(
+                {
+                    "result": "unsafe",
+                    "detail": "Shared access reached a path that should have been denied.",
+                    "auth_mode": "github-broker",
+                    "positive_read": True,
+                    "negative_denied": False,
+                    "secret_count": 8,
+                    "read_only": False,
+                }
+            ),
+            "",
+        )
+
+    report = build_store_verify_report(run=run, ecosystem_cfg=_config())
+
+    assert report["result"] == "unsafe"
+    assert report["checks"]["positive_read"] is True
+    assert report["checks"]["negative_denied"] is False
+
+
+def test_store_verify_never_runs_with_unbounded_or_writable_policy():
+    cfg = _config()
+    cfg["store"]["team_scopes"][0]["access"] = "write"
+
+    def run(_args):
+        raise AssertionError("verification must not run")
+
+    report = build_store_verify_report(run=run, ecosystem_cfg=cfg)
+
+    assert report["result"] == "not-configured"
+    assert report["checks"]["policy_valid"] is False
+
+
+def test_store_verify_never_copies_underlying_stderr_into_report():
+    marker = "secret-value-that-must-not-leak"
+
+    def run(args):
+        return subprocess.CompletedProcess(args, 1, "not-json", marker)
+
+    report = build_store_verify_report(run=run, ecosystem_cfg=_config())
+
+    assert report["result"] == "unavailable"
+    assert marker not in json.dumps(report)

--- a/tools/cc/tests/test_support_contract.py
+++ b/tools/cc/tests/test_support_contract.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+
+from cc.commands.support import build_support_latest_report
+
+
+def _record(run_id: str) -> dict:
+    return {
+        "schema_version": "1.0",
+        "kind": "setup-journey-support-report",
+        "run_id": run_id,
+    }
+
+
+def test_support_latest_returns_newest_private_redacted_record(tmp_path):
+    directory = tmp_path / "control-tower"
+    directory.mkdir()
+    older = directory / "setup-journey-older.json"
+    newer = directory / "setup-journey-newer.json"
+    older.write_text(json.dumps(_record("older")))
+    newer.write_text(json.dumps(_record("newer")))
+    older.chmod(0o600)
+    newer.chmod(0o600)
+    older.touch()
+    newer.touch()
+
+    report = build_support_latest_report(root=tmp_path)
+
+    assert report["result"] == "ready"
+    assert report["report"]["run_id"] == "newer"
+    assert report["path"] == str(newer)
+
+
+def test_support_latest_refuses_world_readable_or_unfamiliar_files(tmp_path):
+    directory = tmp_path / "control-tower"
+    directory.mkdir()
+    unsafe = directory / "setup-journey-unsafe.json"
+    unsafe.write_text(json.dumps(_record("unsafe")))
+    unsafe.chmod(0o644)
+    unfamiliar = directory / "setup-journey-unfamiliar.json"
+    unfamiliar.write_text(json.dumps({"token": "must-not-return"}))
+    unfamiliar.chmod(0o600)
+
+    report = build_support_latest_report(root=tmp_path)
+
+    assert report["result"] == "unavailable"
+    assert "must-not-return" not in json.dumps(report)

--- a/tools/cc/uv.lock
+++ b/tools/cc/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "claude-cli"
-version = "2.11.1"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Outcome

Makes managed-store verification a required Python setup phase and adds paste-ready redacted support reports.

## Behavior

- adds cc store verify --json with bounded scope validation
- adds cc support latest --json with ownership, mode, schema, and symlink checks
- prevents a 0.95 operational claim until the live store proof passes
- names blocked component IDs and local checkpoint outcomes without leaking raw output or credentials
- distinguishes truly stale shared checkouts from authored-ahead and diverged Git histories
- replaces misleading blanket behind copy with an accurate needs-attention action
- bumps cc to 2.12.0

## Verification

- full cc suite passed after the final changes
- touched-file Ruff and format checks passed
- version consistency passed
- wheel and source distribution built successfully
- CodeQL, hardcoded-path, smoke, and onboard-contract hosted checks passed

Independent review is requested from @james-lukensow; administrator bypass has not been used.