### PR TITLE
Verify store against organization canary path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-08-07 — cc 2.12.1
+
+- `cc store verify` now consumes the organization-published, known-nonempty
+  out-of-scope canary path instead of testing an arbitrary nonexistent folder.
+- The store policy fails closed when that verification path is missing,
+  unbounded, or nested inside the authorized scope.
+
 All notable changes to Claude Copilot will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),

--- a/VERSION.json
+++ b/VERSION.json
@@ -3,7 +3,7 @@
   "lastUpdated": "2026-08-07T00:00:00.000Z",
   "components": {
     "cc": {
-      "version": "2.12.0",
+      "version": "2.12.1",
       "path": "tools/cc",
       "installScript": "tools/cc/install.sh",
       "provides": ["cc memory", "cc memory check", "cc skill", "cc config", "cc env", "cc docs", "cc usage", "cc eval", "cc reconcile", "cc store", "cc support"]

--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "2.12.0"
+version = "2.12.1"
 description = "Unified CLI replacing copilot-memory and skills-copilot MCP servers"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI — unified replacement for copilot-memory and skills-copilot MCP servers."""
 
-__version__ = "2.12.0"
+__version__ = "2.12.1"

--- a/tools/cc/src/cc/commands/store.py
+++ b/tools/cc/src/cc/commands/store.py
@@ -101,6 +101,7 @@ def _policy_scope(
         return None, f"The organization does not declare exactly one '{scope}' scope."
     row = matched[0]
     path = row.get("secret_path")
+    verification_path = store.get("verification_path")
     access = row.get("access")
     identity_id = row.get("identity_id")
     workspace = row.get("workspace_id", store.get("workspace_id"))
@@ -117,12 +118,18 @@ def _policy_scope(
         or not workspace
         or not isinstance(environment, str)
         or not environment
+        or not isinstance(verification_path, str)
+        or not verification_path.startswith("/")
+        or verification_path.rstrip("/") in {"", "/"}
+        or any(mark in verification_path for mark in "*?[]{}")
+        or verification_path.rstrip("/") == path.rstrip("/")
+        or verification_path.rstrip("/").startswith(f"{path.rstrip('/')}/")
     ):
         return (
             None,
             f"The organization's '{scope}' scope is not a bounded read-only scope.",
         )
-    return row, None
+    return {**row, "verification_path": verification_path.rstrip("/")}, None
 
 
 def build_store_verify_report(
@@ -168,7 +175,7 @@ def build_store_verify_report(
             "--path",
             path,
             "--negative-path",
-            "/__control_tower_denied__",
+            row["verification_path"],
             "--scope",
             scope,
         )
@@ -200,7 +207,8 @@ def build_store_verify_report(
     reported_result = payload.get("result")
     safe_result = (
         reported_result
-        if reported_result in {"not-configured", "unavailable", "unsafe", "invalid-config"}
+        if reported_result
+        in {"not-configured", "unavailable", "unsafe", "invalid-config"}
         else "unavailable"
     )
     return _report(

--- a/tools/cc/tests/test_store_contract.py
+++ b/tools/cc/tests/test_store_contract.py
@@ -16,6 +16,7 @@ def _config():
             "workspace_id": "workspace-1",
             "environment": "prod",
             "secret_path": "/shared",
+            "verification_path": "/canary",
             "broker_url": "https://access.example.test",
             "broker_issuer": "https://access.example.test",
             "broker_audience": "https://secrets.example.test",
@@ -68,6 +69,7 @@ def test_store_verify_requires_positive_and_negative_live_evidence():
     command = observed[0]
     assert command[:5] == ("copilot", "infisical", "--json", "access", "verify")
     assert "--negative-path" in command
+    assert command[command.index("--negative-path") + 1] == "/canary"
     assert "--scope" in command
 
 
@@ -100,6 +102,19 @@ def test_store_verify_fails_closed_when_negative_scope_is_readable():
 def test_store_verify_never_runs_with_unbounded_or_writable_policy():
     cfg = _config()
     cfg["store"]["team_scopes"][0]["access"] = "write"
+
+    def run(_args):
+        raise AssertionError("verification must not run")
+
+    report = build_store_verify_report(run=run, ecosystem_cfg=cfg)
+
+    assert report["result"] == "not-configured"
+    assert report["checks"]["policy_valid"] is False
+
+
+def test_store_verify_requires_a_bounded_out_of_scope_canary():
+    cfg = _config()
+    cfg["store"].pop("verification_path")
 
     def run(_args):
         raise AssertionError("verification must not run")

--- a/tools/cc/uv.lock
+++ b/tools/cc/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "claude-cli"
-version = "2.12.0"
+version = "2.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
- consume the organization-published known-nonempty out-of-scope canary
- reject missing, root, wildcard, same-scope, or nested canary paths
- pass the bounded canary to the Python Infisical verifier
- bump cc to 2.12.1

## Verification
- full cc suite passed
- focused store/setup suite passed
- ruff check and format clean
- live canary evidence: `/coolify` contains 2 secrets and the shared identity sees 0