### PR TITLE
Install cc into uv-created virtual environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-08-07 — cc 2.12.2
+
+- `tools/cc/install.sh` now bootstraps `pip` inside an existing uv-created
+  virtual environment instead of failing during an otherwise valid upgrade.
+
 ## 2026-08-07 — cc 2.12.1
 
 - `cc store verify` now consumes the organization-published, known-nonempty

--- a/VERSION.json
+++ b/VERSION.json
@@ -3,7 +3,7 @@
   "lastUpdated": "2026-08-07T00:00:00.000Z",
   "components": {
     "cc": {
-      "version": "2.12.1",
+      "version": "2.12.2",
       "path": "tools/cc",
       "installScript": "tools/cc/install.sh",
       "provides": ["cc memory", "cc memory check", "cc skill", "cc config", "cc env", "cc docs", "cc usage", "cc eval", "cc reconcile", "cc store", "cc support"]

--- a/tools/cc/install.sh
+++ b/tools/cc/install.sh
@@ -22,10 +22,22 @@ else
     echo "==> Virtual environment already exists at $VENV_DIR"
 fi
 
+# uv creates valid virtual environments without seeding pip by default. An
+# existing cc development venv may therefore have Python but no pip entry
+# point; bootstrap it in place instead of treating the venv as corrupt.
+if [ ! -x "$VENV_DIR/bin/python" ]; then
+    echo "ERROR: Existing cc virtual environment has no Python interpreter" >&2
+    exit 1
+fi
+if ! "$VENV_DIR/bin/python" -m pip --version >/dev/null 2>&1; then
+    echo "==> Bootstrapping pip in the existing virtual environment"
+    "$VENV_DIR/bin/python" -m ensurepip --upgrade >/dev/null
+fi
+
 # Step 2: Install/upgrade pip and install cc in editable mode
 echo "==> Installing cc in editable mode"
-"$VENV_DIR/bin/pip" install --quiet --upgrade pip
-"$VENV_DIR/bin/pip" install --quiet -e "$SCRIPT_DIR"
+"$VENV_DIR/bin/python" -m pip install --quiet --upgrade pip
+"$VENV_DIR/bin/python" -m pip install --quiet -e "$SCRIPT_DIR"
 
 # Step 3: Ensure shim directory exists
 mkdir -p "$SHIM_DIR"

--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "2.12.1"
+version = "2.12.2"
 description = "Unified CLI replacing copilot-memory and skills-copilot MCP servers"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI — unified replacement for copilot-memory and skills-copilot MCP servers."""
 
-__version__ = "2.12.1"
+__version__ = "2.12.2"

--- a/tools/cc/tests/test_install_script_contract.py
+++ b/tools/cc/tests/test_install_script_contract.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_installer_bootstraps_pip_for_existing_uv_virtual_environment():
+    source = (Path(__file__).parents[1] / "install.sh").read_text(encoding="utf-8")
+
+    assert 'if ! "$VENV_DIR/bin/python" -m pip --version' in source
+    assert '"$VENV_DIR/bin/python" -m ensurepip --upgrade' in source
+    assert source.index("-m ensurepip --upgrade") < source.index(
+        '"$VENV_DIR/bin/python" -m pip install --quiet --upgrade pip'
+    )

--- a/tools/cc/uv.lock
+++ b/tools/cc/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "claude-cli"
-version = "2.12.1"
+version = "2.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
- detect pip through the venv interpreter rather than assuming a `bin/pip` entry point
- bootstrap pip with ensurepip when absent
- perform upgrades through `python -m pip`
- bump cc to 2.12.2

## Verification
- installer contract test passed
- bash syntax check passed
- real upgrade from the existing uv-created venv passed
- installed shim reports cc 2.12.2
- full cc suite passed immediately before this isolated installer patch