### PR TITLE
fix(cc): complete Python onboarding paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-08-07 — cc 2.12.3
+
+- Ecosystem onboarding now verifies the GitHub-authorized, read-only Infisical
+  broker path before consulting retired per-Mac Universal Auth identities, so
+  a working shared store is reported ready in the onboarding ledger.
+- Customized Claude projects may retain the exact project-contained Codex
+  skill bridge, and the single bounded preservation recipe is now eligible for
+  deterministic Python selection without an unnecessary assistant round trip.
+
 ## 2026-08-07 — cc 2.12.2
 
 - `tools/cc/install.sh` now bootstraps `pip` inside an existing uv-created

--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "2.12.2"
+version = "2.12.3"
 description = "Unified CLI replacing copilot-memory and skills-copilot MCP servers"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI — unified replacement for copilot-memory and skills-copilot MCP servers."""
 
-__version__ = "2.12.2"
+__version__ = "2.12.3"

--- a/tools/cc/src/cc/commands/onboard.py
+++ b/tools/cc/src/cc/commands/onboard.py
@@ -2361,6 +2361,10 @@ def _provision_store(store: dict[str, Any], *, apply: bool, run: Run) -> dict[st
                 "result": "ready",
                 "type": "infisical",
                 "scope": scope,
+                "detail": (
+                    "The shared credential store is connected through GitHub "
+                    "and verified read-only."
+                ),
             }
 
     unreachable = {

--- a/tools/cc/src/cc/commands/onboard.py
+++ b/tools/cc/src/cc/commands/onboard.py
@@ -22,6 +22,7 @@ import yaml
 
 from cc.commands.doctor import build_doctor_report
 from cc.commands.resolve import build_resolve_report
+from cc.commands.store import build_store_verify_report
 from cc.commands.update import execute_update
 from cc.core import authstore, keychain
 from cc.core.config import load_machine_config, resolve_key
@@ -2334,6 +2335,34 @@ def _provision_store(store: dict[str, Any], *, apply: bool, run: Run) -> dict[st
     # The onboarding contract deliberately exposes only a non-secret summary
     # string; its schema does not accept arbitrary nested policy.
     scope = f"{store['environment']}:{store['secret_path']}:read"
+
+    # Current organizations authorize interactive store access through the
+    # GitHub broker published in the signed ecosystem config.  Verify that
+    # path before consulting the retired per-Mac Universal Auth identity
+    # surface.  This keeps onboarding and `cc store verify` on one proof:
+    # positive read, known non-empty negative denial, and read-only policy.
+    if all(
+        isinstance(store.get(key), str) and store.get(key)
+        for key in (
+            "endpoint",
+            "broker_url",
+            "broker_issuer",
+            "broker_audience",
+            "verification_path",
+        )
+    ) and isinstance(store.get("team_scopes"), list):
+        broker_report = build_store_verify_report(
+            scope="shared",
+            run=run,
+            ecosystem_cfg={"store": store},
+        )
+        if broker_report.get("result") == "ready":
+            return {
+                "result": "ready",
+                "type": "infisical",
+                "scope": scope,
+            }
+
     unreachable = {
         "result": "deferred",
         "type": "infisical",

--- a/tools/cc/src/cc/core/ecosystem/project_reconciliation.py
+++ b/tools/cc/src/cc/core/ecosystem/project_reconciliation.py
@@ -1064,14 +1064,24 @@ def assess_project(
                 dossier=eligibility_dossier,
             )
             if eligible:
+                directly_selectable = [
+                    definition
+                    for definition in eligible
+                    if not definition.assistant_only
+                ]
+                # An assistant cannot add judgment when exactly one bounded
+                # Python recipe is compatible with the inspected evidence.
+                # Expose that single recipe directly; preserve assistant-only
+                # filtering when multiple safe interpretations exist.
+                if not directly_selectable and len(eligible) == 1:
+                    directly_selectable = list(eligible)
                 component_assessment["recipe_options"] = [
                     {
                         "recipe_id": definition.recipe_id,
                         "component": definition.component,
                         "summary": definition.summary,
                     }
-                    for definition in eligible
-                    if not definition.assistant_only
+                    for definition in directly_selectable
                 ]
             else:
                 route = ComponentRoute.OWNER_DECISION

--- a/tools/cc/src/cc/core/ecosystem/reconciliation_recipes.py
+++ b/tools/cc/src/cc/core/ecosystem/reconciliation_recipes.py
@@ -1384,6 +1384,10 @@ def _safe_claude_project_tree(root: Path) -> bool:
         for entry in entries:
             try:
                 if entry.is_symlink():
+                    if _recognized_internal_codex_skill_bridge(
+                        root, Path(entry.path)
+                    ):
+                        continue
                     return False
                 if entry.is_dir(follow_symlinks=False):
                     pending.append(Path(entry.path))
@@ -1392,6 +1396,25 @@ def _safe_claude_project_tree(root: Path) -> bool:
             except OSError:
                 return False
     return True
+
+
+def _recognized_internal_codex_skill_bridge(root: Path, path: Path) -> bool:
+    """Admit only Codex's exact project-contained skill bridge.
+
+    Claude preservation recipes never write through this link.  The target is
+    the portable Codex plugin already contained by the same project, so this
+    does not grant access to an external shared checkout or broaden the recipe
+    mutation boundary.
+    """
+    try:
+        if path.relative_to(root).as_posix() != ".claude/skills/codex-copilot":
+            return False
+        if path.readlink().as_posix() != "../../plugins/codex-copilot/skills":
+            return False
+        expected = (root / "plugins/codex-copilot/skills").resolve(strict=True)
+        return path.resolve(strict=True) == expected and expected.is_dir()
+    except (OSError, ValueError):
+        return False
 
 
 def _recognized_read_only_knowledge_link(root: Path, target: str) -> bool:

--- a/tools/cc/tests/test_onboard_contract.py
+++ b/tools/cc/tests/test_onboard_contract.py
@@ -2467,6 +2467,10 @@ def test_github_broker_store_verification_precedes_legacy_machine_identity():
         "result": "ready",
         "type": "infisical",
         "scope": "prod:/shared:read",
+        "detail": (
+            "The shared credential store is connected through GitHub and "
+            "verified read-only."
+        ),
     }
     assert len(calls) == 1
     assert calls[0][:5] == (

--- a/tools/cc/tests/test_onboard_contract.py
+++ b/tools/cc/tests/test_onboard_contract.py
@@ -2418,6 +2418,67 @@ def test_identity_list_failure_defers_without_ever_calling_create():
     assert calls == [("copilot", "infisical", "--json", "identity", "list")]
 
 
+def test_github_broker_store_verification_precedes_legacy_machine_identity():
+    store = {
+        "status": "connected",
+        "type": "infisical",
+        "endpoint": "https://secrets.example.test",
+        "workspace_id": "workspace-1",
+        "environment": "prod",
+        "secret_path": "/shared",
+        "verification_path": "/known-nonempty-denied",
+        "broker_url": "https://access.example.test",
+        "broker_issuer": "https://access.example.test",
+        "broker_audience": "https://secrets.example.test",
+        "team_scopes": [
+            {
+                "team": "everyone",
+                "scope": "shared",
+                "environment": "prod",
+                "secret_path": "/shared",
+                "access": "read",
+                "identity_id": "identity-1",
+            }
+        ],
+    }
+    calls: list[tuple[str, ...]] = []
+
+    def run(args: tuple[str, ...]) -> subprocess.CompletedProcess[str]:
+        calls.append(tuple(args))
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            json.dumps(
+                {
+                    "result": "ready",
+                    "positive_read": True,
+                    "negative_denied": True,
+                    "read_only": True,
+                    "auth_mode": "github-broker",
+                    "secret_count": "[REDACTED]",
+                }
+            ),
+            "",
+        )
+
+    report = onboard_module._provision_store(store, apply=True, run=run)
+
+    assert report == {
+        "result": "ready",
+        "type": "infisical",
+        "scope": "prod:/shared:read",
+    }
+    assert len(calls) == 1
+    assert calls[0][:5] == (
+        "copilot",
+        "infisical",
+        "--json",
+        "access",
+        "verify",
+    )
+    assert "identity" not in calls[0]
+
+
 def test_existing_identity_reads_ready_without_ever_calling_create():
     """The common, live-verified case (task 221): this Mac's own Infisical
     credentials already authenticate as an existing org identity --

--- a/tools/cc/tests/test_project_reconciliation_families.py
+++ b/tools/cc/tests/test_project_reconciliation_families.py
@@ -289,6 +289,14 @@ def _build_artifact_case(
             project / ".mcp.json",
             json.dumps({"mcpServers": {"project-tool": {"command": "project-tool"}}}),
         )
+    elif case == "claude-content-with-codex-bridge":
+        _install_current(project, claude_source, codex_source, ("codex",))
+        _write(
+            project / "CLAUDE.md",
+            "# Project-owned Claude routing\n\n## Claude Copilot\n",
+        )
+        _write(project / ".mcp.json", '{"mcpServers": {}}\n')
+        _write(project / ".claude/agents/project-owned.md", "custom agent\n")
     elif case == "skill-bridge":
         outside = tmp_path / "outside-skills"
         outside.mkdir()
@@ -366,6 +374,13 @@ def _build_artifact_case(
             "project-author",
             "claude.customized-preserve-entry.v1",
         ),
+        (
+            "claude-content-with-codex-bridge",
+            "claude",
+            "customized-guided-route",
+            "project-author",
+            "claude.assistant-preserve-entry.v1",
+        ),
         ("skill-bridge", "codex", "could-not-verify", "person", None),
         ("skill-bridge-parent", "codex", "could-not-verify", "person", None),
         (
@@ -442,6 +457,10 @@ def test_artifact_family_routes_and_plans_are_authoritative_and_read_only(
             ),
         ),
         "mcp-config": ("guided-integration", ("compatible-claude-entry",)),
+        "claude-content-with-codex-bridge": (
+            "guided-integration",
+            ("project-owned-component-content",),
+        ),
         "skill-bridge": (
             "could-not-verify",
             (
@@ -477,6 +496,7 @@ def test_artifact_family_routes_and_plans_are_authoritative_and_read_only(
         "claude-entry": "CLAUDE.md",
         "codex-entry": "AGENTS.md",
         "mcp-config": ".mcp.json",
+        "claude-content-with-codex-bridge": ".claude/agents",
         "skill-bridge": ".claude/skills",
         "skill-bridge-parent": ".claude/skills",
         "plugin": "plugins",
@@ -855,6 +875,12 @@ def test_legacy_codex_gate_wrapper_is_replaced_during_portable_migration(
             "CLAUDE.md",
         ),
         (
+            "claude-content-with-codex-bridge",
+            "claude",
+            "claude.assistant-preserve-entry.v1",
+            "CLAUDE.md",
+        ),
+        (
             "config",
             "codex",
             "codex.customized-merge-config.v1",
@@ -928,10 +954,17 @@ def test_custom_family_apply_verifies_and_repeats_without_work(
         (project / "copilot.project.json").read_text(encoding="utf-8")
     )
     assert declaration["projectOwnedSetting"] == "preserve-me"
-    if case == "claude-entry":
+    if case in {"claude-entry", "claude-content-with-codex-bridge"}:
         assert "# Project-owned Claude routing" in (project / "CLAUDE.md").read_text(
             encoding="utf-8"
         )
+        if case == "claude-content-with-codex-bridge":
+            assert (
+                project / ".claude/skills/codex-copilot"
+            ).readlink().as_posix() == "../../plugins/codex-copilot/skills"
+            assert (
+                project / ".claude/agents/project-owned.md"
+            ).read_text(encoding="utf-8") == "custom agent\n"
     elif case == "codex-entry":
         assert "# Project-owned Codex routing" in (project / "AGENTS.md").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- verify the GitHub-authorized read-only store path during ecosystem onboarding
- recognize the exact project-contained Codex skill bridge during Claude preservation
- directly select the sole bounded Python preservation recipe when no assistant judgment exists
- bump cc to 2.12.3

## Verification
- full tools/cc test suite passes
- changed Python files pass ruff
- git diff --check passes