### PR TITLE
fix(cc): make managed blocks idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-08-07 — cc 2.12.4
+
+- Managed project-integration blocks are now repeat-safe: an exact existing
+  block is fingerprinted in place instead of being appended a second time.
+
 ## 2026-08-07 — cc 2.12.3
 
 - Ecosystem onboarding now verifies the GitHub-authorized, read-only Infisical

--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "2.12.3"
+version = "2.12.4"
 description = "Unified CLI replacing copilot-memory and skills-copilot MCP servers"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI — unified replacement for copilot-memory and skills-copilot MCP servers."""
 
-__version__ = "2.12.3"
+__version__ = "2.12.4"

--- a/tools/cc/src/cc/core/ecosystem/reconciliation_recipes.py
+++ b/tools/cc/src/cc/core/ecosystem/reconciliation_recipes.py
@@ -1844,12 +1844,16 @@ def _managed_output_for_operation(
             current = path.read_bytes()
         except FileNotFoundError:
             current = b""
-        separator = (
-            b""
-            if not current or current.endswith(b"\n\n")
-            else (b"\n" if current.endswith(b"\n") else b"\n\n")
-        )
-        content = current + separator + str(operation.payload["block"]).encode("utf-8")
+        block_bytes = str(operation.payload["block"]).encode("utf-8")
+        if block_bytes in current:
+            content = current
+        else:
+            separator = (
+                b""
+                if not current or current.endswith(b"\n\n")
+                else (b"\n" if current.endswith(b"\n") else b"\n\n")
+            )
+            content = current + separator + block_bytes
         mode = int(
             operation.payload.get(
                 "mode",

--- a/tools/cc/src/cc/core/ecosystem/reconciliation_transaction.py
+++ b/tools/cc/src/cc/core/ecosystem/reconciliation_transaction.py
@@ -601,12 +601,16 @@ def _prepare_mutation(
             current = project.read_bytes(target)
         except FileNotFoundError:
             current = b""
-        separator = (
-            b""
-            if not current or current.endswith(b"\n\n")
-            else (b"\n" if current.endswith(b"\n") else b"\n\n")
-        )
-        content = current + separator + block.encode("utf-8")
+        block_bytes = block.encode("utf-8")
+        if block_bytes in current:
+            content = current
+        else:
+            separator = (
+                b""
+                if not current or current.endswith(b"\n\n")
+                else (b"\n" if current.endswith(b"\n") else b"\n\n")
+            )
+            content = current + separator + block_bytes
         mode = int(payload.get("mode", _existing_mode(project, target, 0o644)))
         return _PreparedMutation(
             fingerprint_file_payload(content, mode=mode),

--- a/tools/cc/tests/test_project_reconciliation_families.py
+++ b/tools/cc/tests/test_project_reconciliation_families.py
@@ -955,10 +955,12 @@ def test_custom_family_apply_verifies_and_repeats_without_work(
     )
     assert declaration["projectOwnedSetting"] == "preserve-me"
     if case in {"claude-entry", "claude-content-with-codex-bridge"}:
-        assert "# Project-owned Claude routing" in (project / "CLAUDE.md").read_text(
-            encoding="utf-8"
-        )
+        claude_text = (project / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "# Project-owned Claude routing" in claude_text
         if case == "claude-content-with-codex-bridge":
+            assert claude_text.count(
+                "<!-- cc:project-integration:claude:v1:start -->"
+            ) == 1
             assert (
                 project / ".claude/skills/codex-copilot"
             ).readlink().as_posix() == "../../plugins/codex-copilot/skills"


### PR DESCRIPTION
## Summary
- keep exact existing managed integration blocks in place
- align plan fingerprints with transaction output
- regress the customized Claude + Codex bridge case
- bump cc to 2.12.4

## Verification
- targeted project reconciliation apply test passes
- reconciliation transaction/apply tests pass
- changed files pass ruff and diff check