### PR TITLE
fix(cc): stabilize final project verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-08-07 — cc 2.12.5
+
+- Final machine verification now retries a bounded local checkpoint when its
+  scan races legitimate Product-project edits. The retry applies only to
+  dirty-working-tree holds, remains fail-closed for every other condition,
+  never pushes Product work, and keeps shared setup access download-only.
+
 ## 2026-08-07 — cc 2.12.4
 
 - Managed project-integration blocks are now repeat-safe: an exact existing

--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "2.12.4"
+version = "2.12.5"
 description = "Unified CLI replacing copilot-memory and skills-copilot MCP servers"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI — unified replacement for copilot-memory and skills-copilot MCP servers."""
 
-__version__ = "2.12.4"
+__version__ = "2.12.5"

--- a/tools/cc/src/cc/core/ecosystem/setup_journey.py
+++ b/tools/cc/src/cc/core/ecosystem/setup_journey.py
@@ -76,6 +76,37 @@ def _default_request(assessment: Mapping[str, Any]) -> dict[str, Any] | None:
     return {"schema_version": "1.0", "roots": roots, "projects": projects}
 
 
+def _has_only_dirty_product_holds(assessment: Mapping[str, Any]) -> bool:
+    """Return whether another local checkpoint can resolve every remaining hold."""
+    machine = assessment.get("machine")
+    if not isinstance(machine, Mapping) or machine.get("state") != "ready":
+        return False
+    if machine.get("blockers"):
+        return False
+
+    found_dirty_hold = False
+    for project in assessment.get("projects", []):
+        if not isinstance(project, Mapping):
+            continue
+        scope = project.get("scope")
+        if not isinstance(scope, Mapping) or scope.get("kind") != "product-project":
+            continue
+        route = project.get("route")
+        if route == "ready":
+            continue
+        blockers = project.get("blockers")
+        if route != "held" or not isinstance(blockers, list) or not blockers:
+            return False
+        if any(
+            not isinstance(blocker, Mapping)
+            or blocker.get("code") != "dirty-working-tree"
+            for blocker in blockers
+        ):
+            return False
+        found_dirty_hold = True
+    return found_dirty_hold
+
+
 def build_setup_journey_report(
     *,
     recover_builder: ReportBuilder = build_recover_report,
@@ -89,6 +120,7 @@ def build_setup_journey_report(
         write_setup_journey_diagnostic
     ),
     max_project_passes: int = 4,
+    max_final_stabilization_passes: int = 3,
 ) -> dict[str, Any]:
     """Recover, prepare, update, apply safe work, and verify the whole scope."""
     phases: list[dict[str, Any]] = []
@@ -177,20 +209,29 @@ def build_setup_journey_report(
         actions.extend(checkpoint.get("completed_actions", []))
 
     # A project may become dirty while the longer machine scan is running.
-    # Make the last action before verification another Product-only checkpoint
-    # and shared-repository refresh, then assess that resulting state.
-    try:
-        final_preparation = prepare_builder()
-    except Exception as exc:
-        final_preparation = _failure("prepare", exc)
-    phases.append(final_preparation)
-    actions.extend(final_preparation.get("completed_actions", []))
+    # Stabilize again immediately before verification. If that verification
+    # races another legitimate Product edit, retry only that bounded, safe
+    # checkpoint path. Every other failure remains fail-closed.
+    final_assessment: dict[str, Any] | None = None
+    for _pass in range(max(1, max_final_stabilization_passes)):
+        try:
+            final_preparation = prepare_builder()
+        except Exception as exc:
+            final_preparation = _failure("prepare", exc)
+        phases.append(final_preparation)
+        actions.extend(final_preparation.get("completed_actions", []))
 
-    try:
-        final_assessment = assess_builder()
-    except Exception as exc:
-        phases.append(_failure("verify", exc))
-        return _result(phases, actions, None, diagnostics_writer)
+        try:
+            final_assessment = assess_builder()
+        except Exception as exc:
+            phases.append(_failure("verify", exc))
+            return _result(phases, actions, None, diagnostics_writer)
+        if final_assessment.get("result") == "ready":
+            break
+        if not _has_only_dirty_product_holds(final_assessment):
+            break
+
+    assert final_assessment is not None
     phases.append({**final_assessment, "phase": "verify-all"})
     return _result(phases, actions, final_assessment, diagnostics_writer)
 

--- a/tools/cc/tests/test_setup_journey.py
+++ b/tools/cc/tests/test_setup_journey.py
@@ -99,6 +99,93 @@ def test_journey_applies_safe_defaults_then_reassesses_and_checkpoints(
     assert report["operational"] is True
 
 
+def test_journey_retries_when_final_verification_races_product_edits(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "cc.core.ecosystem.setup_journey.resolve_key",
+        lambda key: "Example-Org" if key == "github_app.org" else "/repos",
+    )
+    dirty = {
+        "phase": "assess",
+        "result": "action-required",
+        "machine": {"state": "ready", "blockers": []},
+        "projects": [
+            {
+                "path": "/projects/one",
+                "scope": {"kind": "product-project"},
+                "route": "held",
+                "blockers": [{"code": "dirty-working-tree"}],
+            }
+        ],
+        "default_selection": [],
+    }
+    assessments = iter((deepcopy(dirty), deepcopy(dirty), _ready_assessment()))
+    preparations: list[int] = []
+
+    def prepare():
+        preparations.append(1)
+        return {"phase": "prepare", "result": "ready", "completed_actions": []}
+
+    report = build_setup_journey_report(
+        recover_builder=lambda: {"phase": "recover", "result": "ready"},
+        prepare_builder=prepare,
+        ecosystem_builder=lambda **kwargs: {
+            "result": "ready",
+            "completed_actions": [],
+        },
+        store_builder=_ready_store,
+        assess_builder=lambda: next(assessments),
+        diagnostics_writer=lambda report: {"state": "available", "path": "/report"},
+    )
+
+    assert len(preparations) == 3
+    assert report["operational"] is True
+
+
+def test_journey_caps_final_dirty_project_stabilization(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "cc.core.ecosystem.setup_journey.resolve_key",
+        lambda key: "Example-Org" if key == "github_app.org" else "/repos",
+    )
+    dirty = {
+        "phase": "assess",
+        "result": "action-required",
+        "machine": {"state": "ready", "blockers": []},
+        "projects": [
+            {
+                "path": "/projects/one",
+                "scope": {"kind": "product-project"},
+                "route": "held",
+                "blockers": [{"code": "dirty-working-tree"}],
+            }
+        ],
+        "default_selection": [],
+    }
+    preparations: list[int] = []
+
+    def prepare():
+        preparations.append(1)
+        return {"phase": "prepare", "result": "ready", "completed_actions": []}
+
+    report = build_setup_journey_report(
+        recover_builder=lambda: {"phase": "recover", "result": "ready"},
+        prepare_builder=prepare,
+        ecosystem_builder=lambda **kwargs: {
+            "result": "ready",
+            "completed_actions": [],
+        },
+        store_builder=_ready_store,
+        assess_builder=lambda: deepcopy(dirty),
+        diagnostics_writer=lambda report: {"state": "available", "path": "/report"},
+        max_final_stabilization_passes=2,
+    )
+
+    assert len(preparations) == 3
+    assert report["operational"] is False
+    assert report["confidence"] == 0.0
+
+
 def test_journey_never_claims_operational_when_external_phase_is_held(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- retry the final Product-project checkpoint when verification races legitimate dirty work
- limit retries to dirty-working-tree holds on otherwise healthy Product projects
- remain fail-closed for every other hold, never push Product work, and keep shared setup download-only
- bump cc to 2.12.5

## Verification
- ruff check on the changed Python files
- focused setup-journey, preflight, and diagnostic tests
- full tools/cc pytest suite
