### PR TITLE
fix(cc): verify integrated projects during active work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-08-07 — cc 2.12.6
+
+- Read-only verification no longer treats unrelated, active Product work as an
+  integration failure when every locked Claude and Codex component still
+  matches its verified fingerprint. Dirty projects that need any setup or
+  update remain held and are never mutated without a safe checkpoint.
+
 ## 2026-08-07 — cc 2.12.5
 
 - Final machine verification now retries a bounded local checkpoint when its

--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "2.12.5"
+version = "2.12.6"
 description = "Unified CLI replacing copilot-memory and skills-copilot MCP servers"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI — unified replacement for copilot-memory and skills-copilot MCP servers."""
 
-__version__ = "2.12.5"
+__version__ = "2.12.6"

--- a/tools/cc/src/cc/core/ecosystem/project_reconciliation.py
+++ b/tools/cc/src/cc/core/ecosystem/project_reconciliation.py
@@ -460,7 +460,6 @@ def _dirty_paths_are_repeat_safe(
     ):
         return False
 
-    allowed: set[str] = set()
     recorded: set[str] = set()
     seen_components: set[str] = set()
     for entry in lock["components"]:
@@ -495,7 +494,6 @@ def _dirty_paths_are_repeat_safe(
             ):
                 return False
             recorded.add(str(relative))
-            allowed.add(relative)
         target_kinds = _MANAGED_OUTPUT_TARGET_KINDS[str(component)]
         for output in managed_outputs:
             if not isinstance(output, Mapping) or set(output) != {
@@ -521,16 +519,12 @@ def _dirty_paths_are_repeat_safe(
             ):
                 return False
             recorded.add(str(relative))
-            allowed.add(relative)
 
-    if "codex" in ready:
-        bridge = ".claude/skills/codex-copilot"
-        if _path_fingerprint(project, bridge) == fingerprint_symlink(
-            "../../plugins/codex-copilot/skills"
-        ):
-            allowed.add(bridge)
-    allowed.add("copilot.lock.json")
-    return set(dirty_paths) <= allowed
+    # Dirty Product-owned files do not invalidate an already complete
+    # integration. The locked framework files above still have to match their
+    # fingerprints exactly, so this permits read-only verification while work
+    # continues without permitting any reconciliation mutation.
+    return True
 
 
 def _component_presence(component: Mapping[str, Any]) -> bool | None:

--- a/tools/cc/tests/test_project_reconciliation.py
+++ b/tools/cc/tests/test_project_reconciliation.py
@@ -365,6 +365,46 @@ def test_unstable_projects_are_held_with_exact_reason(
     }
 
 
+def test_dirty_product_work_does_not_invalidate_ready_integrations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stable_environment: Path,
+) -> None:
+    del stable_environment
+    project = _project(tmp_path)
+    _write(
+        project / "copilot.lock.json",
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "components": [
+                    {"component": "claude", "files": [], "managed_outputs": []},
+                    {"component": "codex", "files": [], "managed_outputs": []},
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+    )
+    _write(project / "product-work.txt", "base\n")
+    _git(project, "add", "copilot.lock.json", "product-work.txt")
+    _git(project, "commit", "-qm", "base")
+    _write(project / "product-work.txt", "active work\n")
+    monkeypatch.setattr(
+        reconciliation,
+        "inspect_project_integration",
+        lambda path, detail: _report("ready", "ready"),
+    )
+
+    assessment = assess_project(project, approved_root=tmp_path)
+
+    assert assessment["route"] == "ready"
+    assert assessment["blockers"] == []
+    assert {item["state"] for item in assessment["components"]} == {"ready"}
+    assert assessment["dossier"]["current_evidence"][0]["state"] == "dirty"
+
+
 def test_exclusion_is_primary_and_content_is_unchanged(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tools/cc/tests/test_project_reconciliation_families.py
+++ b/tools/cc/tests/test_project_reconciliation_families.py
@@ -1165,7 +1165,7 @@ def test_stale_custom_recipe_ids_are_rejected_against_current_targets(
         )
 
 
-def test_ready_project_with_unrelated_dirty_path_is_held(
+def test_ready_project_with_unrelated_dirty_path_remains_verified(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     claude_source, codex_source = _framework_sources(tmp_path)
@@ -1178,8 +1178,9 @@ def test_ready_project_with_unrelated_dirty_path_is_held(
     assessment = assess_project(
         project, approved_root=tmp_path, selected_components=("claude",)
     )
-    assert assessment["route"] == "held"
-    assert _component(assessment, "claude")["state"] == "held"
+    assert assessment["route"] == "ready"
+    assert _component(assessment, "claude")["state"] == "ready"
+    assert assessment["blockers"] == []
     _, plans = build_project_plans([assessment], {str(project): ("claude",)})
     assert plans[0].operations == ()
 
@@ -1216,7 +1217,7 @@ def test_modified_managed_entry_is_held(
     assert _component(assessment, "claude")["recipe_options"] == []
 
 
-def test_ready_project_with_renamed_unrelated_path_is_held(
+def test_ready_project_with_renamed_unrelated_path_remains_verified(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     claude_source, codex_source = _framework_sources(tmp_path)
@@ -1230,8 +1231,9 @@ def test_ready_project_with_renamed_unrelated_path_is_held(
     assessment = assess_project(
         project, approved_root=tmp_path, selected_components=("claude",)
     )
-    assert assessment["route"] == "held"
-    assert _component(assessment, "claude")["state"] == "held"
+    assert assessment["route"] == "ready"
+    assert _component(assessment, "claude")["state"] == "ready"
+    assert assessment["blockers"] == []
 
 
 def test_detached_ready_project_is_held(


### PR DESCRIPTION
## Summary
- keep already-integrated Product projects verifiable during unrelated active work
- continue fingerprint verification for every locked framework-owned artifact
- keep dirty projects held whenever any component needs setup or update
- bump cc to 2.12.6

## Verification
- ruff check on changed reconciliation files
- focused reconciliation, family, setup journey, and preflight tests
- full tools/cc pytest suite
