### PR TITLE
fix(cc): restore immutable helper release lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-08-07 — cc 2.12.7
+
+- The committed `uv.lock` now matches the released package version, restoring
+  the immutable macOS helper build's `uv export --locked` gate. Release
+  packaging still refuses to regenerate dependencies or bypass the lock.
+
 ## 2026-08-07 — cc 2.12.6
 
 - Read-only verification no longer treats unrelated, active Product work as an

--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "2.12.6"
+version = "2.12.7"
 description = "Unified CLI replacing copilot-memory and skills-copilot MCP servers"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI — unified replacement for copilot-memory and skills-copilot MCP servers."""
 
-__version__ = "2.12.6"
+__version__ = "2.12.7"

--- a/tools/cc/uv.lock
+++ b/tools/cc/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "claude-cli"
-version = "2.12.2"
+version = "2.12.7"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
- bump cc to 2.12.7
- refresh the committed uv lock package version
- restore the macOS release build's immutable `uv export --locked` gate

## Verification
- `uv lock --check`
- 21 targeted tests pass
- targeted ruff check passes
- reproduced v5.13.62 packaging refusal before the fix