### PR TITLE
Enforce signed immutable Knowledge skill reads

### DIFF
--- a/tools/cc/src/cc/commands/deprovision.py
+++ b/tools/cc/src/cc/commands/deprovision.py
@@ -49,6 +49,7 @@ def build_deprovision_report(
     _lockfile_path: Any = _UNSET,
     _mirror_root: Any = _UNSET,
     _materialize_root: Any = _UNSET,
+    _knowledge_snapshot_root: Any = _UNSET,
     _mode: str = "soft",
     _personal_roots: Any = _UNSET,
     _dry_run: bool = False,
@@ -107,6 +108,32 @@ def build_deprovision_report(
         personal_roots=personal_roots,
         dry_run=_dry_run,
     )
+
+    snapshot_removed = 0
+    if _mode == "hard":
+        if _knowledge_snapshot_root is not _UNSET:
+            snapshot_root = Path(_knowledge_snapshot_root).expanduser()
+        elif _mirror_root is _UNSET and _materialize_root is _UNSET:
+            skill_cache = resolve_key("skills.cache_dir")
+            snapshot_root = (
+                Path(str(skill_cache)).expanduser()
+                if skill_cache
+                else None
+            )
+            if snapshot_root is not None:
+                snapshot_root /= "signed-knowledge-v1"
+        else:
+            # Injected engine tests do not gain authority over machine state.
+            snapshot_root = None
+        if snapshot_root is not None:
+            from cc.core.ecosystem.knowledge_skill_source import (
+                prune_all_knowledge_snapshots,
+            )
+
+            snapshot_removed = prune_all_knowledge_snapshots(
+                cache_root=snapshot_root, dry_run=_dry_run
+            )
+            engine_report["removed_materialized"] += snapshot_removed
 
     removed_materialized = engine_report["removed_materialized"]
     removed_clones = engine_report["removed_clones"]

--- a/tools/cc/src/cc/commands/skill.py
+++ b/tools/cc/src/cc/commands/skill.py
@@ -72,6 +72,17 @@ def _load_all_skills(scope: str = "all"):
     return discover_skills_with_sources(pairs, cache_dir=_resolve_skill_cache_dir())
 
 
+def _load_trusted_skills(scope: str = "all"):
+    """Map fail-closed Knowledge verification to a concise CLI error."""
+    from cc.core.ecosystem.knowledge_skill_source import KnowledgeSkillSourceError
+
+    try:
+        return _load_all_skills(scope)
+    except KnowledgeSkillSourceError as exc:
+        err_console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+
 def _skill_to_dict(s: Any, *, include_path: bool = True) -> dict[str, Any]:
     """Shared `--json` serialization for a `SkillMeta` (WP-372 P2.2): every
     frontmatter fact beyond the canonical named fields -- `triggers`
@@ -110,7 +121,7 @@ def skill_list(
         )
         raise typer.Exit(1)
 
-    skills = _load_all_skills(scope)
+    skills = _load_trusted_skills(scope)
 
     if output_json:
         data = [_skill_to_dict(s) for s in skills]
@@ -157,7 +168,7 @@ def skill_search(
         )
         raise typer.Exit(1)
 
-    all_skills = _load_all_skills(scope)
+    all_skills = _load_trusted_skills(scope)
     results = search_skills(query, all_skills)
 
     if output_json:
@@ -199,7 +210,7 @@ def skill_get(
     """
     from cc.core.skill_store import find_skill_by_name, get_skill_content
 
-    skills = _load_all_skills(scope)
+    skills = _load_trusted_skills(scope)
     skill = find_skill_by_name(name, skills)
 
     if skill is None:
@@ -228,14 +239,16 @@ def skill_path(
         # → /path/to/.claude/skills/security/stride-dread/SKILL.md
         @include $(cc skill path stride-dread)
     """
-    from cc.core.skill_store import find_skill_by_name
+    from cc.core.skill_store import find_skill_by_name, revalidate_skill_path
 
-    skills = _load_all_skills(scope)
+    skills = _load_trusted_skills(scope)
     skill = find_skill_by_name(name, skills)
 
     if skill is None:
         err_console.print(f"[red]Skill not found:[/red] {name!r}")
         raise typer.Exit(2)
+
+    revalidate_skill_path(skill)
 
     # Plain text — deliberately no newline decoration so output is pipeable
     typer.echo(str(skill.path))

--- a/tools/cc/src/cc/core/ecosystem/entitlement.py
+++ b/tools/cc/src/cc/core/ecosystem/entitlement.py
@@ -586,10 +586,24 @@ def observe_layer(
             and not isinstance(record_revision, bool)
             and record_revision >= sequence
         ):
-            return replace(
-                _cached_decision(layer, record, login=login, now=current),
+            authoritative_login = (
+                record.get("login")
+                if isinstance(record, dict) and isinstance(record.get("login"), str)
+                else None
+            )
+            current_decision = replace(
+                _cached_decision(
+                    layer, record, login=authoritative_login, now=current
+                ),
                 superseded=True,
             )
+            _reconcile_knowledge_snapshot_authority(
+                layer,
+                current_decision,
+                state_path=path,
+                login=authoritative_login,
+            )
+            return current_decision
 
         if record is not None:
             checked = _parse_timestamp(record.get("checked_at"))
@@ -648,26 +662,66 @@ def observe_layer(
             "revision": sequence,
         }
         _write_state(path, records, next_sequence=next_sequence)
-    if state == "entitled":
-        return _decision(
-            layer_id,
-            state,
-            True,
-            checked_at=_timestamp(current),
-            expires_at=_timestamp(current + OFFLINE_GRACE),
-            revision=sequence,
+        if state == "entitled":
+            decision = _decision(
+                layer_id,
+                state,
+                True,
+                checked_at=_timestamp(current),
+                expires_at=_timestamp(current + OFFLINE_GRACE),
+                revision=sequence,
+            )
+        elif state == "offline":
+            decision = replace(
+                _cached_decision(
+                    layer, records[layer_id], login=stored_login, now=current
+                ),
+                revision=sequence,
+            )
+        else:
+            decision = _decision(
+                layer_id,
+                state,
+                False,
+                checked_at=_timestamp(current),
+                revision=sequence,
+            )
+        _reconcile_knowledge_snapshot_authority(
+            layer, decision, state_path=path, login=stored_login
         )
-    if state == "offline":
-        return replace(
-            _cached_decision(layer, records[layer_id], login=stored_login, now=current),
-            revision=sequence,
-        )
-    return _decision(
-        layer_id,
-        state,
-        False,
-        checked_at=_timestamp(current),
-        revision=sequence,
+    return decision
+
+
+def _reconcile_knowledge_snapshot_authority(
+    layer: dict[str, object],
+    decision: EntitlementDecision,
+    *,
+    state_path: Path,
+    login: str | None,
+) -> None:
+    """Keep protected Knowledge snapshots only for the current eligible row.
+
+    The caller holds the entitlement ledger lock, establishing the global
+    ledger-before-snapshot lock order used by the resolver as well. A terminal,
+    stale, or superseded decision atomically removes the prior pathname before
+    the observation returns.
+    """
+    if str(layer.get("product", "")).lower() != "knowledge":
+        return
+    source = layer.get("source")
+    repository = github_repo_slug(source.get("repo")) if isinstance(source, dict) else None
+    if repository is None:
+        return
+    from cc.core.ecosystem.knowledge_skill_source import (
+        prune_protected_knowledge_snapshots,
+    )
+
+    prune_protected_knowledge_snapshots(
+        layer=decision.layer,
+        repository=repository.casefold(),
+        state_path=state_path,
+        keep_login=login if decision.eligible else None,
+        keep_revision=decision.revision if decision.eligible else None,
     )
 
 

--- a/tools/cc/src/cc/core/ecosystem/knowledge_skill_source.py
+++ b/tools/cc/src/cc/core/ecosystem/knowledge_skill_source.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
+import secrets
 import shutil
 import stat
 import subprocess
@@ -29,6 +31,8 @@ from cc.core.ecosystem.policy import (
 )
 from cc.core.ecosystem.project_locking import (
     UnsafeProjectPath,
+    advisory_file_lock,
+    atomic_json_write,
     ensure_private_directory,
     fsync_directory,
 )
@@ -52,6 +56,8 @@ class VerifiedKnowledgeSkillSource:
     tree: str
     signer: str
     snapshot: GitTreeSnapshot
+    snapshot_cache_root: Path
+    entitlement_binding: entitlement.EntitlementBinding | None = None
 
     def skill_files(self) -> tuple[Path, ...]:
         """Return SKILL.md paths enumerated by the immutable Git tree."""
@@ -69,21 +75,60 @@ class VerifiedKnowledgeSkillSource:
             raise KnowledgeSkillSourceError(
                 "The requested Knowledge skill is absent from its signed release."
             )
+
+        def read_current() -> bytes:
+            with advisory_file_lock(
+                _snapshot_lock_path(self.snapshot_cache_root), blocking=True
+            ):
+                if not _snapshot_matches(self.skills_root, self.snapshot):
+                    raise KnowledgeSkillSourceError(
+                        "The authenticated Knowledge snapshot is unavailable."
+                    )
+                expected_mode = 0o500 if item.mode & 0o111 else 0o400
+                content = _read_private_file(path, expected_mode=expected_mode)
+                if content != item.content:
+                    raise KnowledgeSkillSourceError(
+                        "The authenticated Knowledge snapshot changed before use."
+                    )
+                return content
+
+        if self.entitlement_binding is None:
+            content = read_current()
+        else:
+            valid, content = entitlement.run_under_binding_leases(
+                [self.entitlement_binding], read_current
+            )
+            if not valid or content is None:
+                raise KnowledgeSkillSourceError(
+                    "Knowledge authorization changed before use; retry the command."
+                )
         try:
-            return item.content.decode("utf-8")
+            return content.decode("utf-8")
         except UnicodeDecodeError as exc:
             raise KnowledgeSkillSourceError(
                 "The requested Knowledge skill is not valid UTF-8."
             ) from exc
 
 
-def _snapshot_cache_root() -> Path:
+SNAPSHOT_INDEX_SCHEMA_VERSION = "1.0"
+_SNAPSHOT_INDEX_NAME = "index.json"
+_SNAPSHOT_LOCK_NAME = ".lifecycle.lock"
+_DIGEST = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _snapshot_lock_path(base: Path) -> Path:
+    return base / _SNAPSHOT_LOCK_NAME
+
+
+def _snapshot_cache_root(*, create: bool = True) -> Path:
     """Return a private, non-symlinked root for authenticated snapshots."""
     from cc.core import config
 
     raw = config.resolve_key("skills.cache_dir")
     cache_root = _nominal(raw or Path.home() / ".claude" / "cache" / "skills")
     snapshots = cache_root / "signed-knowledge-v1"
+    if not create and not snapshots.exists() and not snapshots.is_symlink():
+        return snapshots
     try:
         ensure_private_directory(cache_root, boundary=cache_root)
         ensure_private_directory(snapshots, boundary=cache_root)
@@ -92,6 +137,339 @@ def _snapshot_cache_root() -> Path:
             "The private Knowledge snapshot cache is unsafe."
         ) from exc
     return snapshots
+
+
+def _empty_snapshot_index() -> dict[str, Any]:
+    return {"schema_version": SNAPSHOT_INDEX_SCHEMA_VERSION, "entries": {}}
+
+
+def _valid_snapshot_entry(key: str, value: object) -> bool:
+    if not _DIGEST.fullmatch(key) or not isinstance(value, dict):
+        return False
+    if set(value) != {
+        "binding",
+        "protected",
+        "layer",
+        "repository",
+        "login",
+        "revision",
+        "ref",
+        "tree",
+        "signer",
+        "state_path",
+        "target",
+        "status",
+    }:
+        return False
+    target = value.get("target")
+    relative = Path(target) if isinstance(target, str) else Path("/")
+    protected = value.get("protected")
+    protected_target = (
+        len(relative.parts) == 4
+        and relative.parts[0] == "protected"
+        and all(_DIGEST.fullmatch(part) for part in relative.parts[1:])
+    )
+    public_target = (
+        len(relative.parts) == 2
+        and relative.parts[0] == "public"
+        and _DIGEST.fullmatch(relative.parts[1])
+    )
+    return bool(
+        value.get("binding") == key
+        and isinstance(protected, bool)
+        and isinstance(value.get("layer"), str)
+        and value.get("layer")
+        and isinstance(value.get("repository"), str)
+        and value.get("repository")
+        and (value.get("login") is None or isinstance(value.get("login"), str))
+        and (
+            value.get("revision") is None
+            or isinstance(value.get("revision"), int)
+            and not isinstance(value.get("revision"), bool)
+            and value.get("revision") >= 0
+        )
+        and all(
+            isinstance(value.get(field), str) and value.get(field)
+            for field in ("ref", "tree", "signer")
+        )
+        and (
+            isinstance(value.get("state_path"), str) and value.get("state_path")
+            if protected
+            else value.get("state_path") is None
+        )
+        and value.get("status") in {"pending", "active"}
+        and isinstance(target, str)
+        and not relative.is_absolute()
+        and ".." not in relative.parts
+        and (protected_target if protected else public_target)
+        and relative.parts[-1] == key
+        and (
+            value.get("revision") is not None
+            if protected
+            else value.get("revision") is None and value.get("login") is None
+        )
+    )
+
+
+def _load_snapshot_index(base: Path) -> dict[str, Any]:
+    path = base / _SNAPSHOT_INDEX_NAME
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return _empty_snapshot_index()
+    except OSError as exc:
+        raise KnowledgeSkillSourceError(
+            "The private Knowledge snapshot index is unavailable."
+        ) from exc
+    if (
+        path.is_symlink()
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+    ):
+        raise KnowledgeSkillSourceError(
+            "The private Knowledge snapshot index is unsafe."
+        )
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise KnowledgeSkillSourceError(
+            "The private Knowledge snapshot index is invalid."
+        ) from exc
+    if (
+        not isinstance(raw, dict)
+        or set(raw) != {"schema_version", "entries"}
+        or raw.get("schema_version") != SNAPSHOT_INDEX_SCHEMA_VERSION
+        or not isinstance(raw.get("entries"), dict)
+        or not all(_valid_snapshot_entry(key, value) for key, value in raw["entries"].items())
+    ):
+        raise KnowledgeSkillSourceError(
+            "The private Knowledge snapshot index is invalid."
+        )
+    return raw
+
+
+def _write_snapshot_index(base: Path, index: dict[str, Any]) -> None:
+    try:
+        atomic_json_write(base / _SNAPSHOT_INDEX_NAME, index)
+    except (OSError, UnsafeProjectPath) as exc:
+        raise KnowledgeSkillSourceError(
+            "The private Knowledge snapshot index could not be updated."
+        ) from exc
+
+
+def _scope_digest(*values: object) -> str:
+    encoded = json.dumps(
+        ["signed-knowledge-scope-v1", *values],
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _snapshot_relative_target(
+    binding: str, *, layer: str, repository: str, login: str | None, revision: int
+) -> Path:
+    scope = _scope_digest(layer, repository, login)
+    generation = _scope_digest(revision)
+    return Path("protected") / scope / generation / binding
+
+
+def _recover_snapshot_state(base: Path, index: dict[str, Any]) -> None:
+    """Recover interrupted prune/publication without broad deletion authority."""
+    changed = False
+    entries = index["entries"]
+    for key, entry in list(entries.items()):
+        target = base / entry["target"]
+        if entry["status"] == "pending" or not target.exists() or target.is_symlink():
+            if target.exists() or target.is_symlink():
+                _remove_snapshot_target(base, Path(entry["target"]))
+            entries.pop(key)
+            changed = True
+    for candidate in base.iterdir():
+        if not re.fullmatch(r"\.reap-[0-9a-f]{32}", candidate.name):
+            continue
+        try:
+            metadata = candidate.lstat()
+        except OSError:
+            continue
+        if (
+            stat.S_ISDIR(metadata.st_mode)
+            and not stat.S_ISLNK(metadata.st_mode)
+            and metadata.st_uid == os.geteuid()
+        ):
+            _make_stage_writable(candidate)
+            shutil.rmtree(candidate, ignore_errors=True)
+    if changed:
+        _write_snapshot_index(base, index)
+
+
+def _remove_snapshot_target(base: Path, relative: Path) -> bool:
+    protected_target = (
+        len(relative.parts) == 4
+        and relative.parts[0] == "protected"
+        and all(_DIGEST.fullmatch(part) for part in relative.parts[1:])
+    )
+    public_target = (
+        len(relative.parts) == 2
+        and relative.parts[0] == "public"
+        and bool(_DIGEST.fullmatch(relative.parts[1]))
+    )
+    if relative.is_absolute() or ".." in relative.parts or not (
+        protected_target or public_target
+    ):
+        raise KnowledgeSkillSourceError(
+            "The private Knowledge snapshot index contains an unsafe target."
+        )
+    target = base / relative
+    try:
+        metadata = target.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise KnowledgeSkillSourceError(
+            "A protected Knowledge snapshot could not be inspected."
+        ) from exc
+    if stat.S_ISLNK(metadata.st_mode):
+        try:
+            target.unlink()
+            fsync_directory(target.parent)
+            return True
+        except OSError as exc:
+            raise KnowledgeSkillSourceError(
+                "A protected Knowledge snapshot link could not be revoked."
+            ) from exc
+    if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != os.geteuid():
+        raise KnowledgeSkillSourceError(
+            "A protected Knowledge snapshot target is unsafe."
+        )
+    tombstone = base / f".reap-{secrets.token_hex(16)}"
+    try:
+        os.rename(target, tombstone)
+        fsync_directory(target.parent)
+        fsync_directory(base)
+    except OSError as exc:
+        raise KnowledgeSkillSourceError(
+            "A protected Knowledge snapshot could not be revoked atomically."
+        ) from exc
+    _make_stage_writable(tombstone)
+    shutil.rmtree(tombstone, ignore_errors=True)
+    return True
+
+
+def _revoke_protected_root(base: Path) -> None:
+    """Invalidate every protected pathname if its private index is corrupt."""
+    protected = base / "protected"
+    try:
+        metadata = protected.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise KnowledgeSkillSourceError(
+            "The protected Knowledge snapshot root could not be inspected."
+        ) from exc
+    if stat.S_ISLNK(metadata.st_mode):
+        try:
+            protected.unlink()
+            fsync_directory(base)
+            return
+        except OSError as exc:
+            raise KnowledgeSkillSourceError(
+                "The protected Knowledge snapshot root could not be revoked."
+            ) from exc
+    if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != os.geteuid():
+        raise KnowledgeSkillSourceError(
+            "The protected Knowledge snapshot root is unsafe."
+        )
+    tombstone = base / f".reap-{secrets.token_hex(16)}"
+    try:
+        os.rename(protected, tombstone)
+        fsync_directory(base)
+    except OSError as exc:
+        raise KnowledgeSkillSourceError(
+            "The protected Knowledge snapshot root could not be revoked."
+        ) from exc
+    _make_stage_writable(tombstone)
+    shutil.rmtree(tombstone, ignore_errors=True)
+
+
+def prune_protected_knowledge_snapshots(
+    *,
+    layer: str | None = None,
+    repository: str | None = None,
+    state_path: Path | str | None = None,
+    keep_login: str | None = None,
+    keep_revision: int | None = None,
+    cache_root: Path | str | None = None,
+    dry_run: bool = False,
+) -> int:
+    """Prune exact indexed protected snapshots; never scan arbitrary paths."""
+    base = (
+        _nominal(cache_root)
+        if cache_root is not None
+        else _snapshot_cache_root(create=False)
+    )
+    if not base.exists():
+        return 0
+    with advisory_file_lock(_snapshot_lock_path(base), blocking=True):
+        try:
+            index = _load_snapshot_index(base)
+        except KnowledgeSkillSourceError:
+            # The index grants precise per-entry cleanup authority.  If it is
+            # corrupt, invalidate only the dedicated protected root so a stale
+            # disclosed path cannot survive by corrupting cleanup metadata.
+            if not dry_run:
+                _revoke_protected_root(base)
+            raise
+        _recover_snapshot_state(base, index)
+        selected: list[tuple[str, dict[str, Any]]] = []
+        normalized_state = str(Path(state_path).expanduser()) if state_path is not None else None
+        for key, entry in index["entries"].items():
+            if not entry["protected"]:
+                continue
+            if layer is not None and entry["layer"] != layer:
+                continue
+            if repository is not None and entry["repository"] != repository:
+                continue
+            if normalized_state is not None and entry["state_path"] != normalized_state:
+                continue
+            if (
+                keep_revision is not None
+                and entry["revision"] == keep_revision
+                and entry["login"] == keep_login
+            ):
+                continue
+            selected.append((key, entry))
+        if dry_run:
+            return len(selected)
+        for key, entry in selected:
+            _remove_snapshot_target(base, Path(entry["target"]))
+            index["entries"].pop(key, None)
+        if selected:
+            _write_snapshot_index(base, index)
+        return len(selected)
+
+
+def prune_all_knowledge_snapshots(
+    *, cache_root: Path | str, dry_run: bool = False
+) -> int:
+    """Hard-deprovision every exact framework-indexed Knowledge snapshot."""
+    base = _nominal(cache_root)
+    if not base.exists():
+        return 0
+    with advisory_file_lock(_snapshot_lock_path(base), blocking=True):
+        index = _load_snapshot_index(base)
+        _recover_snapshot_state(base, index)
+        entries = list(index["entries"].items())
+        if dry_run:
+            return len(entries)
+        for key, entry in entries:
+            _remove_snapshot_target(base, Path(entry["target"]))
+            index["entries"].pop(key, None)
+        if entries:
+            _write_snapshot_index(base, index)
+        return len(entries)
 
 
 def _snapshot_binding(
@@ -162,7 +540,10 @@ def _snapshot_matches(target: Path, snapshot: GitTreeSnapshot) -> bool:
             not stat.S_ISDIR(root_metadata.st_mode)
             or stat.S_ISLNK(root_metadata.st_mode)
             or root_metadata.st_uid != os.geteuid()
-            or stat.S_IMODE(root_metadata.st_mode) != 0o500
+            # The publication root remains 0700 so macOS can atomically
+            # rename it during revocation.  Every descendant and file stays
+            # read/execute-only and every read verifies the exact tree.
+            or stat.S_IMODE(root_metadata.st_mode) != 0o700
         ):
             return False
         expected_files = {item.path: item for item in snapshot.files}
@@ -231,10 +612,11 @@ def _materialize_snapshot(
     ref: str,
     tree: str,
     signer: str,
+    entitlement_binding: entitlement.EntitlementBinding | None,
 ) -> Path:
     """Atomically publish exact Git-object bytes under a private digest path."""
     base = _snapshot_cache_root()
-    binding = _snapshot_binding(
+    content_binding = _snapshot_binding(
         repository=repository,
         layer=layer,
         ref=ref,
@@ -242,7 +624,74 @@ def _materialize_snapshot(
         signer=signer,
         snapshot=snapshot,
     )
-    target = base / binding
+    if entitlement_binding is None:
+        binding = content_binding
+        relative_target = Path("public") / binding
+        index_entry = {
+            "binding": binding,
+            "protected": False,
+            "layer": layer,
+            "repository": repository,
+            "login": None,
+            "revision": None,
+            "ref": ref,
+            "tree": tree,
+            "signer": signer,
+            "state_path": None,
+            "target": relative_target.as_posix(),
+            "status": "pending",
+        }
+    else:
+        # A protected cache identity is both content-addressed and authority-
+        # generation-addressed.  Reauthorization may select the same Git tree,
+        # but it must never revive the pathname disclosed by an older grant.
+        binding = _scope_digest(
+            content_binding,
+            layer,
+            repository,
+            entitlement_binding.login,
+            entitlement_binding.revision,
+        )
+        relative_target = _snapshot_relative_target(
+            binding,
+            layer=layer,
+            repository=repository,
+            login=entitlement_binding.login,
+            revision=entitlement_binding.revision,
+        )
+        index_entry = {
+            "binding": binding,
+            "protected": True,
+            "layer": layer,
+            "repository": repository,
+            "login": entitlement_binding.login,
+            "revision": entitlement_binding.revision,
+            "ref": ref,
+            "tree": tree,
+            "signer": signer,
+            "state_path": entitlement_binding.state_path,
+            "target": relative_target.as_posix(),
+            "status": "pending",
+        }
+    target = base / relative_target
+    ensure_private_directory(target.parent, boundary=base)
+
+    index = _load_snapshot_index(base)
+    _recover_snapshot_state(base, index)
+    recorded = index["entries"].get(binding)
+    if recorded is not None:
+        if recorded != (index_entry | {"status": "active"}):
+            raise KnowledgeSkillSourceError(
+                "A Knowledge snapshot binding conflicts with its private index."
+            )
+        if _snapshot_matches(target, snapshot):
+            return target
+        raise KnowledgeSkillSourceError(
+            "A cached Knowledge snapshot failed integrity verification."
+        )
+    index["entries"][binding] = index_entry
+    _write_snapshot_index(base, index)
+
     if target.exists() or target.is_symlink():
         if _snapshot_matches(target, snapshot):
             return target
@@ -250,7 +699,7 @@ def _materialize_snapshot(
             "A cached Knowledge snapshot failed integrity verification."
         )
 
-    stage = Path(tempfile.mkdtemp(prefix=f".{binding}.", dir=base))
+    stage = Path(tempfile.mkdtemp(prefix=f".{binding}.", dir=target.parent))
     try:
         stage.chmod(0o700)
         for item in snapshot.files:
@@ -280,18 +729,21 @@ def _materialize_snapshot(
             fsync_directory(directory)
             directory.chmod(0o500)
         fsync_directory(stage)
-        stage.chmod(0o500)
+        stage.chmod(0o700)
 
         try:
             os.rename(stage, target)
         except OSError:
             if not _snapshot_matches(target, snapshot):
                 raise
+        fsync_directory(target.parent)
         fsync_directory(base)
         if not _snapshot_matches(target, snapshot):
             raise KnowledgeSkillSourceError(
                 "The authenticated Knowledge snapshot changed during publication."
             )
+        index["entries"][binding]["status"] = "active"
+        _write_snapshot_index(base, index)
         return target
     except KnowledgeSkillSourceError:
         raise
@@ -376,14 +828,22 @@ def _signed_policy(layer: dict[str, Any]) -> list[str] | None:
 
 
 def _effective_knowledge_layers(
-    manifest_source: Any, mirror_root_base: Path | str
-) -> tuple[list[dict[str, Any]], set[str]]:
+    knowledge: list[dict[str, Any]],
+    mirror_root_base: Path | str,
+    *,
+    state_path: Path,
+    login: str | None,
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[entitlement.EntitlementDecision],
+]:
     try:
-        layers = validate_layers(load_layers(manifest_source))
-        knowledge = [layer for layer in layers if layer.get("product") == "knowledge"]
         if not knowledge:
-            return [], set()
-        eligible, _decisions = entitlement.filter_eligible_layers(knowledge)
+            return [], [], []
+        eligible, decisions = entitlement.filter_eligible_layers(
+            knowledge, state_path=state_path, login=login
+        )
         effective = synthesize_effective_layers(
             knowledge, mirror_root_base=mirror_root_base
         )
@@ -391,7 +851,7 @@ def _effective_knowledge_layers(
         raise KnowledgeSkillSourceError(
             "The configured Knowledge layer manifest is invalid."
         ) from exc
-    return effective, {str(layer.get("id")) for layer in eligible}
+    return effective, eligible, decisions
 
 
 def resolve_knowledge_skill_sources(
@@ -399,6 +859,8 @@ def resolve_knowledge_skill_sources(
     repositories: Iterable[str] | None = None,
     manifest_source: Any = None,
     mirror_root_base: Path | str | None = None,
+    entitlement_state_path_value: Path | str | None = None,
+    entitlement_login: str | None = None,
 ) -> list[tuple[Path, VerifiedKnowledgeSkillSource | None]]:
     """Resolve configured roots and authenticate every signed matching layer.
 
@@ -422,92 +884,176 @@ def resolve_knowledge_skill_sources(
             for repo in configured_repositories
             if (_nominal(repo) / KNOWLEDGE_SKILLS_SUBPATH).is_dir()
         ]
+    try:
+        layers = validate_layers(load_layers(configured_manifest))
+        declared_knowledge = [
+            layer for layer in layers if layer.get("product") == "knowledge"
+        ]
+    except (ManifestError, OSError, TypeError, ValueError) as exc:
+        raise KnowledgeSkillSourceError(
+            "The configured Knowledge layer manifest is invalid."
+        ) from exc
     mirrors = (
         config.resolve_key("paths.mirrors_root")
         if mirror_root_base is None
         else mirror_root_base
     )
-    effective, eligible_ids = _effective_knowledge_layers(
-        configured_manifest, mirrors or Path.home() / ".copilot" / "mirrors"
+    protected_declared = [
+        layer for layer in declared_knowledge if entitlement.is_protected_layer(layer)
+    ]
+    if protected_declared:
+        state_path = (
+            Path(entitlement_state_path_value).expanduser()
+            if entitlement_state_path_value is not None
+            else entitlement.entitlement_state_path()
+        )
+        login = (
+            entitlement_login
+            if entitlement_login is not None
+            else entitlement.current_login()
+        )
+    else:
+        # Public/anonymous Knowledge must not require or even inspect account
+        # state.  This sentinel is never consumed when no layer is protected.
+        state_path = Path("/")
+        login = None
+    effective, eligible, decisions = _effective_knowledge_layers(
+        declared_knowledge,
+        mirrors or Path.home() / ".copilot" / "mirrors",
+        state_path=state_path,
+        login=login,
     )
-    result: list[tuple[Path, VerifiedKnowledgeSkillSource | None]] = []
-    for repo_value in configured_repositories:
-        repo = _nominal(repo_value)
-        skills_root = repo / KNOWLEDGE_SKILLS_SUBPATH
-        matches = [
-            layer
-            for layer in effective
-            if isinstance((layer.get("source") or {}).get("path"), str)
-            and _nominal((layer.get("source") or {})["path"]) == repo
-        ]
-        if len(matches) > 1:
-            raise KnowledgeSkillSourceError(
-                "A configured Knowledge repository matches more than one layer."
-            )
-        if not matches:
-            if skills_root.is_dir():
-                result.append((skills_root, None))
-            continue
-        layer = matches[0]
-        signers = _signed_policy(layer)
-        if signers is None:
-            if skills_root.is_dir():
-                result.append((skills_root, None))
-            continue
-        if str(layer.get("id")) not in eligible_ids:
-            continue
-        source = layer.get("source") or {}
-        ref = source.get("ref")
-        expected_repository = repository_identity(source.get("repo"))
-        if not isinstance(ref, str) or not ref or expected_repository is None:
-            raise KnowledgeSkillSourceError(
-                "The effective Knowledge layer lacks immutable source provenance."
-            )
-        verified = verify_git_item_provenance(
-            repo, KNOWLEDGE_SKILLS_SUBPATH, signers, ref=ref
+    eligible_ids = {str(layer.get("id")) for layer in eligible}
+    decision_by_id = {decision.layer: decision for decision in decisions}
+    declared_by_id = {
+        str(layer.get("id")): layer
+        for layer in declared_knowledge
+    }
+    bindings = (
+        entitlement.bind_layer_decisions(
+            list(declared_by_id.values()),
+            decisions,
+            state_path=state_path,
+            login=login,
         )
-        if verified is None:
-            raise KnowledgeSkillSourceError(
-                "The effective Knowledge skills do not match their signed release."
+        if protected_declared
+        else ()
+    )
+    binding_by_id = {binding.layer: binding for binding in bindings}
+
+    def resolve_bound() -> list[tuple[Path, VerifiedKnowledgeSkillSource | None]]:
+        result: list[tuple[Path, VerifiedKnowledgeSkillSource | None]] = []
+        protected_ids = {
+            layer_id
+            for layer_id, layer in declared_by_id.items()
+            if entitlement.is_protected_layer(layer)
+        }
+        base = _snapshot_cache_root()
+        for layer_id in protected_ids:
+            layer = declared_by_id[layer_id]
+            source = layer.get("source") or {}
+            repository = repository_identity(source.get("repo"))
+            decision = decision_by_id.get(layer_id)
+            if repository is None or decision is None:
+                continue
+            prune_protected_knowledge_snapshots(
+                layer=layer_id,
+                repository=repository,
+                state_path=state_path,
+                keep_login=login if decision.eligible else None,
+                keep_revision=decision.revision if decision.eligible else None,
+                cache_root=base,
             )
-        repository_root = Path(verified.repository_root)
-        if _origin(repository_root) != expected_repository:
-            raise KnowledgeSkillSourceError(
-                "The effective Knowledge checkout has the wrong repository origin."
+
+        for repo_value in configured_repositories:
+            repo = _nominal(repo_value)
+            skills_root = repo / KNOWLEDGE_SKILLS_SUBPATH
+            matches = [
+                layer
+                for layer in effective
+                if isinstance((layer.get("source") or {}).get("path"), str)
+                and _nominal((layer.get("source") or {})["path"]) == repo
+            ]
+            if len(matches) > 1:
+                raise KnowledgeSkillSourceError(
+                    "A configured Knowledge repository matches more than one layer."
+                )
+            if not matches:
+                if skills_root.is_dir():
+                    result.append((skills_root, None))
+                continue
+            layer = matches[0]
+            signers = _signed_policy(layer)
+            if signers is None:
+                if skills_root.is_dir():
+                    result.append((skills_root, None))
+                continue
+            layer_id = str(layer.get("id"))
+            if layer_id not in eligible_ids:
+                continue
+            source = layer.get("source") or {}
+            ref = source.get("ref")
+            expected_repository = repository_identity(source.get("repo"))
+            if not isinstance(ref, str) or not ref or expected_repository is None:
+                raise KnowledgeSkillSourceError(
+                    "The effective Knowledge layer lacks immutable source provenance."
+                )
+            verified = verify_git_item_provenance(
+                repo, KNOWLEDGE_SKILLS_SUBPATH, signers, ref=ref
             )
-        if _has_ignored_additions(repository_root, verified.relative_path):
-            raise KnowledgeSkillSourceError(
-                "The effective Knowledge skills contain ignored local additions."
-            )
-        snapshot = read_git_tree_snapshot(repository_root, verified.tree)
-        if snapshot is None:
-            raise KnowledgeSkillSourceError(
-                "The signed Knowledge skill tree contains an unsafe Git object."
-            )
-        layer_id = str(layer["id"])
-        materialized_root = _materialize_snapshot(
-            snapshot,
-            repository=expected_repository,
-            layer=layer_id,
-            ref=verified.ref,
-            tree=verified.tree,
-            signer=verified.signer,
-        )
-        result.append(
-            (
-                materialized_root,
-                VerifiedKnowledgeSkillSource(
-                    skills_root=materialized_root,
-                    repository_root=repository_root,
-                    relative_path=verified.relative_path,
+            if verified is None:
+                raise KnowledgeSkillSourceError(
+                    "The effective Knowledge skills do not match their signed release."
+                )
+            repository_root = Path(verified.repository_root)
+            if _origin(repository_root) != expected_repository:
+                raise KnowledgeSkillSourceError(
+                    "The effective Knowledge checkout has the wrong repository origin."
+                )
+            if _has_ignored_additions(repository_root, verified.relative_path):
+                raise KnowledgeSkillSourceError(
+                    "The effective Knowledge skills contain ignored local additions."
+                )
+            snapshot = read_git_tree_snapshot(repository_root, verified.tree)
+            if snapshot is None:
+                raise KnowledgeSkillSourceError(
+                    "The signed Knowledge skill tree contains an unsafe Git object."
+                )
+            entitlement_binding = binding_by_id.get(layer_id)
+            with advisory_file_lock(_snapshot_lock_path(base), blocking=True):
+                materialized_root = _materialize_snapshot(
+                    snapshot,
                     repository=expected_repository,
                     layer=layer_id,
                     ref=verified.ref,
                     tree=verified.tree,
                     signer=verified.signer,
-                    snapshot=snapshot,
-                ),
+                    entitlement_binding=entitlement_binding,
+                )
+            result.append(
+                (
+                    materialized_root,
+                    VerifiedKnowledgeSkillSource(
+                        skills_root=materialized_root,
+                        repository_root=repository_root,
+                        relative_path=verified.relative_path,
+                        repository=expected_repository,
+                        layer=layer_id,
+                        ref=verified.ref,
+                        tree=verified.tree,
+                        signer=verified.signer,
+                        snapshot=snapshot,
+                        snapshot_cache_root=base,
+                        entitlement_binding=entitlement_binding,
+                    ),
+                )
             )
+        return result
+
+    valid, result = entitlement.run_under_binding_leases(bindings, resolve_bound)
+    if not valid or result is None:
+        raise KnowledgeSkillSourceError(
+            "Knowledge authorization changed during resolution; retry the command."
         )
     return result
 
@@ -523,7 +1069,16 @@ def revalidate_knowledge_skill_source(
     )
     if source is None or any(
         getattr(source, field) != getattr(expected, field)
-        for field in ("repository", "layer", "ref", "tree", "signer")
+        for field in (
+            "skills_root",
+            "repository",
+            "layer",
+            "ref",
+            "tree",
+            "signer",
+            "snapshot_cache_root",
+            "entitlement_binding",
+        )
     ):
         raise KnowledgeSkillSourceError(
             "The Knowledge source changed after it was selected; retry the command."
@@ -535,6 +1090,8 @@ __all__ = [
     "KNOWLEDGE_SKILLS_SUBPATH",
     "KnowledgeSkillSourceError",
     "VerifiedKnowledgeSkillSource",
+    "prune_all_knowledge_snapshots",
+    "prune_protected_knowledge_snapshots",
     "resolve_knowledge_skill_sources",
     "revalidate_knowledge_skill_source",
 ]

--- a/tools/cc/src/cc/core/ecosystem/knowledge_skill_source.py
+++ b/tools/cc/src/cc/core/ecosystem/knowledge_skill_source.py
@@ -1,0 +1,293 @@
+"""Authenticated Knowledge skill sources.
+
+Configured Knowledge repositories predate the ecosystem manifest and remain
+valid when no signed layer declares them.  Once a matching effective layer
+declares signer policy, however, the mutable checkout is no longer authority:
+the signed annotated tag and its exact skill-tree Git object are.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from cc.core.ecosystem import entitlement
+from cc.core.ecosystem.manifest import ManifestError, load_layers, validate_layers
+from cc.core.ecosystem.mirror import synthesize_effective_layers
+from cc.core.ecosystem.policy import (
+    GitTreeSnapshot,
+    read_git_tree_snapshot,
+    verify_git_item_provenance,
+)
+from cc.core.ecosystem.repository_scope import repository_identity
+
+KNOWLEDGE_SKILLS_SUBPATH = "03-ai-enabling/01-skills"
+
+
+class KnowledgeSkillSourceError(ValueError):
+    """A signed Knowledge source could not earn read authority."""
+
+
+@dataclass(frozen=True)
+class VerifiedKnowledgeSkillSource:
+    skills_root: Path
+    repository_root: Path
+    relative_path: str
+    repository: str
+    layer: str
+    ref: str
+    tree: str
+    signer: str
+    snapshot: GitTreeSnapshot
+
+    def skill_files(self) -> tuple[Path, ...]:
+        """Return SKILL.md paths enumerated by the immutable Git tree."""
+        return tuple(
+            self.skills_root / item.path
+            for item in self.snapshot.files
+            if item.path == "SKILL.md" or item.path.endswith("/SKILL.md")
+        )
+
+    def read_text(self, path: Path) -> str:
+        """Read one skill from authenticated object bytes, never the checkout."""
+        relative = _relative_skill_path(self.skills_root, path)
+        item = next((row for row in self.snapshot.files if row.path == relative), None)
+        if item is None:
+            raise KnowledgeSkillSourceError(
+                "The requested Knowledge skill is absent from its signed release."
+            )
+        try:
+            return item.content.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise KnowledgeSkillSourceError(
+                "The requested Knowledge skill is not valid UTF-8."
+            ) from exc
+
+
+def _nominal(path: Path | str) -> Path:
+    return Path(os.path.abspath(Path(path).expanduser()))
+
+
+def _relative_skill_path(root: Path, path: Path) -> str:
+    nominal = _nominal(path)
+    try:
+        relative = nominal.relative_to(root)
+    except ValueError as exc:
+        raise KnowledgeSkillSourceError(
+            "The requested Knowledge skill escapes its signed source."
+        ) from exc
+    if relative.is_absolute() or ".." in relative.parts:
+        raise KnowledgeSkillSourceError(
+            "The requested Knowledge skill escapes its signed source."
+        )
+    return relative.as_posix()
+
+
+def _origin(root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return repository_identity(result.stdout.strip()) if result.returncode == 0 else None
+
+
+def _has_ignored_additions(root: Path, relative_path: str) -> bool:
+    """Reject ignored files that Git's ordinary untracked listing omits."""
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "ls-files",
+                "--others",
+                "--ignored",
+                "--exclude-standard",
+                "--",
+                relative_path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return True
+    return result.returncode != 0 or bool(result.stdout.strip())
+
+
+def _signed_policy(layer: dict[str, Any]) -> list[str] | None:
+    policy = layer.get("policy")
+    signers = policy.get("allowed_signers") if isinstance(policy, dict) else None
+    if not isinstance(signers, list) or not signers:
+        return None
+    if not all(isinstance(item, str) and item.strip() for item in signers):
+        raise KnowledgeSkillSourceError(
+            "A Knowledge layer declares an invalid signer policy."
+        )
+    return signers
+
+
+def _effective_knowledge_layers(
+    manifest_source: Any, mirror_root_base: Path | str
+) -> tuple[list[dict[str, Any]], set[str]]:
+    try:
+        layers = validate_layers(load_layers(manifest_source))
+        knowledge = [layer for layer in layers if layer.get("product") == "knowledge"]
+        if not knowledge:
+            return [], set()
+        eligible, _decisions = entitlement.filter_eligible_layers(knowledge)
+        effective = synthesize_effective_layers(
+            knowledge, mirror_root_base=mirror_root_base
+        )
+    except (ManifestError, OSError, TypeError, ValueError) as exc:
+        raise KnowledgeSkillSourceError(
+            "The configured Knowledge layer manifest is invalid."
+        ) from exc
+    return effective, {str(layer.get("id")) for layer in eligible}
+
+
+def resolve_knowledge_skill_sources(
+    *,
+    repositories: Iterable[str] | None = None,
+    manifest_source: Any = None,
+    mirror_root_base: Path | str | None = None,
+) -> list[tuple[Path, VerifiedKnowledgeSkillSource | None]]:
+    """Resolve configured roots and authenticate every signed matching layer.
+
+    The ``None`` source is the explicit compatibility state for a configured
+    repository that has no signed matching layer.  A signed but ineligible
+    layer is excluded; a signed eligible layer that cannot verify blocks.
+    """
+    from cc.core import config
+
+    configured_repositories = list(
+        config.resolve_knowledge_repos() if repositories is None else repositories
+    )
+    configured_manifest = (
+        config.resolve_key("layers.manifest")
+        if manifest_source is None
+        else manifest_source
+    )
+    if not configured_manifest:
+        return [
+            (_nominal(repo) / KNOWLEDGE_SKILLS_SUBPATH, None)
+            for repo in configured_repositories
+            if (_nominal(repo) / KNOWLEDGE_SKILLS_SUBPATH).is_dir()
+        ]
+    mirrors = (
+        config.resolve_key("paths.mirrors_root")
+        if mirror_root_base is None
+        else mirror_root_base
+    )
+    effective, eligible_ids = _effective_knowledge_layers(
+        configured_manifest, mirrors or Path.home() / ".copilot" / "mirrors"
+    )
+    result: list[tuple[Path, VerifiedKnowledgeSkillSource | None]] = []
+    for repo_value in configured_repositories:
+        repo = _nominal(repo_value)
+        skills_root = repo / KNOWLEDGE_SKILLS_SUBPATH
+        matches = [
+            layer
+            for layer in effective
+            if isinstance((layer.get("source") or {}).get("path"), str)
+            and _nominal((layer.get("source") or {})["path"]) == repo
+        ]
+        if len(matches) > 1:
+            raise KnowledgeSkillSourceError(
+                "A configured Knowledge repository matches more than one layer."
+            )
+        if not matches:
+            if skills_root.is_dir():
+                result.append((skills_root, None))
+            continue
+        layer = matches[0]
+        signers = _signed_policy(layer)
+        if signers is None:
+            if skills_root.is_dir():
+                result.append((skills_root, None))
+            continue
+        if str(layer.get("id")) not in eligible_ids:
+            continue
+        source = layer.get("source") or {}
+        ref = source.get("ref")
+        expected_repository = repository_identity(source.get("repo"))
+        if not isinstance(ref, str) or not ref or expected_repository is None:
+            raise KnowledgeSkillSourceError(
+                "The effective Knowledge layer lacks immutable source provenance."
+            )
+        verified = verify_git_item_provenance(
+            repo, KNOWLEDGE_SKILLS_SUBPATH, signers, ref=ref
+        )
+        if verified is None:
+            raise KnowledgeSkillSourceError(
+                "The effective Knowledge skills do not match their signed release."
+            )
+        repository_root = Path(verified.repository_root)
+        if _origin(repository_root) != expected_repository:
+            raise KnowledgeSkillSourceError(
+                "The effective Knowledge checkout has the wrong repository origin."
+            )
+        if _has_ignored_additions(repository_root, verified.relative_path):
+            raise KnowledgeSkillSourceError(
+                "The effective Knowledge skills contain ignored local additions."
+            )
+        snapshot = read_git_tree_snapshot(repository_root, verified.tree)
+        if snapshot is None:
+            raise KnowledgeSkillSourceError(
+                "The signed Knowledge skill tree contains an unsafe Git object."
+            )
+        result.append(
+            (
+                skills_root,
+                VerifiedKnowledgeSkillSource(
+                    skills_root=skills_root,
+                    repository_root=repository_root,
+                    relative_path=verified.relative_path,
+                    repository=expected_repository,
+                    layer=str(layer["id"]),
+                    ref=verified.ref,
+                    tree=verified.tree,
+                    signer=verified.signer,
+                    snapshot=snapshot,
+                ),
+            )
+        )
+    return result
+
+
+def revalidate_knowledge_skill_source(
+    expected: VerifiedKnowledgeSkillSource,
+) -> VerifiedKnowledgeSkillSource:
+    """Require the same layer/ref/tree/signer to remain currently authorized."""
+    current = resolve_knowledge_skill_sources()
+    source = next(
+        (candidate for root, candidate in current if root == expected.skills_root),
+        None,
+    )
+    if source is None or any(
+        getattr(source, field) != getattr(expected, field)
+        for field in ("repository", "layer", "ref", "tree", "signer")
+    ):
+        raise KnowledgeSkillSourceError(
+            "The Knowledge source changed after it was selected; retry the command."
+        )
+    return source
+
+
+__all__ = [
+    "KNOWLEDGE_SKILLS_SUBPATH",
+    "KnowledgeSkillSourceError",
+    "VerifiedKnowledgeSkillSource",
+    "resolve_knowledge_skill_sources",
+    "revalidate_knowledge_skill_source",
+]

--- a/tools/cc/src/cc/core/ecosystem/knowledge_skill_source.py
+++ b/tools/cc/src/cc/core/ecosystem/knowledge_skill_source.py
@@ -8,8 +8,13 @@ the signed annotated tag and its exact skill-tree Git object are.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
+import shutil
+import stat
 import subprocess
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -21,6 +26,11 @@ from cc.core.ecosystem.policy import (
     GitTreeSnapshot,
     read_git_tree_snapshot,
     verify_git_item_provenance,
+)
+from cc.core.ecosystem.project_locking import (
+    UnsafeProjectPath,
+    ensure_private_directory,
+    fsync_directory,
 )
 from cc.core.ecosystem.repository_scope import repository_identity
 
@@ -65,6 +75,234 @@ class VerifiedKnowledgeSkillSource:
             raise KnowledgeSkillSourceError(
                 "The requested Knowledge skill is not valid UTF-8."
             ) from exc
+
+
+def _snapshot_cache_root() -> Path:
+    """Return a private, non-symlinked root for authenticated snapshots."""
+    from cc.core import config
+
+    raw = config.resolve_key("skills.cache_dir")
+    cache_root = _nominal(raw or Path.home() / ".claude" / "cache" / "skills")
+    snapshots = cache_root / "signed-knowledge-v1"
+    try:
+        ensure_private_directory(cache_root, boundary=cache_root)
+        ensure_private_directory(snapshots, boundary=cache_root)
+    except (OSError, UnsafeProjectPath) as exc:
+        raise KnowledgeSkillSourceError(
+            "The private Knowledge snapshot cache is unsafe."
+        ) from exc
+    return snapshots
+
+
+def _snapshot_binding(
+    *,
+    repository: str,
+    layer: str,
+    ref: str,
+    tree: str,
+    signer: str,
+    snapshot: GitTreeSnapshot,
+) -> str:
+    encoded = json.dumps(
+        [
+            "signed-knowledge-v1",
+            repository,
+            layer,
+            ref,
+            tree,
+            signer,
+            snapshot.fingerprint(),
+        ],
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _snapshot_directories(snapshot: GitTreeSnapshot) -> set[str]:
+    result: set[str] = set()
+    for item in snapshot.files:
+        parent = Path(item.path).parent
+        while parent != Path("."):
+            result.add(parent.as_posix())
+            parent = parent.parent
+    return result
+
+
+def _read_private_file(path: Path, *, expected_mode: int) -> bytes | None:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(metadata.st_mode) != expected_mode
+        ):
+            return None
+        chunks: list[bytes] = []
+        while chunk := os.read(descriptor, 1024 * 1024):
+            chunks.append(chunk)
+        return b"".join(chunks)
+    except OSError:
+        return None
+    finally:
+        os.close(descriptor)
+
+
+def _snapshot_matches(target: Path, snapshot: GitTreeSnapshot) -> bool:
+    """Require exact bytes, shape, modes, and ownership in a cached tree."""
+    try:
+        root_metadata = target.lstat()
+        if (
+            not stat.S_ISDIR(root_metadata.st_mode)
+            or stat.S_ISLNK(root_metadata.st_mode)
+            or root_metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(root_metadata.st_mode) != 0o500
+        ):
+            return False
+        expected_files = {item.path: item for item in snapshot.files}
+        expected_directories = _snapshot_directories(snapshot)
+        observed_files: set[str] = set()
+        observed_directories: set[str] = set()
+        for root, directories, files in os.walk(target, followlinks=False):
+            root_path = Path(root)
+            for name in directories:
+                candidate = root_path / name
+                metadata = candidate.lstat()
+                relative = candidate.relative_to(target).as_posix()
+                if (
+                    not stat.S_ISDIR(metadata.st_mode)
+                    or stat.S_ISLNK(metadata.st_mode)
+                    or metadata.st_uid != os.geteuid()
+                    or stat.S_IMODE(metadata.st_mode) != 0o500
+                ):
+                    return False
+                observed_directories.add(relative)
+            for name in files:
+                candidate = root_path / name
+                relative = candidate.relative_to(target).as_posix()
+                expected = expected_files.get(relative)
+                if expected is None:
+                    return False
+                expected_mode = 0o500 if expected.mode & 0o111 else 0o400
+                content = _read_private_file(candidate, expected_mode=expected_mode)
+                if content is None or content != expected.content:
+                    return False
+                observed_files.add(relative)
+        return (
+            observed_files == set(expected_files)
+            and observed_directories == expected_directories
+        )
+    except (OSError, ValueError):
+        return False
+
+
+def _make_stage_writable(stage: Path) -> None:
+    """Best-effort cleanup preparation for an unpublished private stage."""
+    if not stage.exists() or stage.is_symlink():
+        return
+    for root, directories, files in os.walk(stage, topdown=False, followlinks=False):
+        for name in files:
+            try:
+                (Path(root) / name).chmod(0o600)
+            except OSError:
+                pass
+        for name in directories:
+            try:
+                (Path(root) / name).chmod(0o700)
+            except OSError:
+                pass
+    try:
+        stage.chmod(0o700)
+    except OSError:
+        pass
+
+
+def _materialize_snapshot(
+    snapshot: GitTreeSnapshot,
+    *,
+    repository: str,
+    layer: str,
+    ref: str,
+    tree: str,
+    signer: str,
+) -> Path:
+    """Atomically publish exact Git-object bytes under a private digest path."""
+    base = _snapshot_cache_root()
+    binding = _snapshot_binding(
+        repository=repository,
+        layer=layer,
+        ref=ref,
+        tree=tree,
+        signer=signer,
+        snapshot=snapshot,
+    )
+    target = base / binding
+    if target.exists() or target.is_symlink():
+        if _snapshot_matches(target, snapshot):
+            return target
+        raise KnowledgeSkillSourceError(
+            "A cached Knowledge snapshot failed integrity verification."
+        )
+
+    stage = Path(tempfile.mkdtemp(prefix=f".{binding}.", dir=base))
+    try:
+        stage.chmod(0o700)
+        for item in snapshot.files:
+            destination = stage / item.path
+            destination.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            descriptor = os.open(
+                destination,
+                os.O_CREAT
+                | os.O_EXCL
+                | os.O_WRONLY
+                | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+            )
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(item.content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            final_mode = 0o500 if item.mode & 0o111 else 0o400
+            destination.chmod(final_mode)
+
+        directories = sorted(
+            (candidate for candidate in stage.rglob("*") if candidate.is_dir()),
+            key=lambda candidate: len(candidate.parts),
+            reverse=True,
+        )
+        for directory in directories:
+            fsync_directory(directory)
+            directory.chmod(0o500)
+        fsync_directory(stage)
+        stage.chmod(0o500)
+
+        try:
+            os.rename(stage, target)
+        except OSError:
+            if not _snapshot_matches(target, snapshot):
+                raise
+        fsync_directory(base)
+        if not _snapshot_matches(target, snapshot):
+            raise KnowledgeSkillSourceError(
+                "The authenticated Knowledge snapshot changed during publication."
+            )
+        return target
+    except KnowledgeSkillSourceError:
+        raise
+    except OSError as exc:
+        raise KnowledgeSkillSourceError(
+            "The authenticated Knowledge snapshot could not be published safely."
+        ) from exc
+    finally:
+        if stage.exists() and stage != target:
+            _make_stage_writable(stage)
+            shutil.rmtree(stage, ignore_errors=True)
 
 
 def _nominal(path: Path | str) -> Path:
@@ -246,15 +484,24 @@ def resolve_knowledge_skill_sources(
             raise KnowledgeSkillSourceError(
                 "The signed Knowledge skill tree contains an unsafe Git object."
             )
+        layer_id = str(layer["id"])
+        materialized_root = _materialize_snapshot(
+            snapshot,
+            repository=expected_repository,
+            layer=layer_id,
+            ref=verified.ref,
+            tree=verified.tree,
+            signer=verified.signer,
+        )
         result.append(
             (
-                skills_root,
+                materialized_root,
                 VerifiedKnowledgeSkillSource(
-                    skills_root=skills_root,
+                    skills_root=materialized_root,
                     repository_root=repository_root,
                     relative_path=verified.relative_path,
                     repository=expected_repository,
-                    layer=str(layer["id"]),
+                    layer=layer_id,
                     ref=verified.ref,
                     tree=verified.tree,
                     signer=verified.signer,

--- a/tools/cc/src/cc/core/ecosystem/policy.py
+++ b/tools/cc/src/cc/core/ecosystem/policy.py
@@ -193,6 +193,32 @@ def _ssh_signer_fingerprint(*streams: str) -> str | None:
     return match.group(1) if match else None
 
 
+def _resolve_tag_object(
+    root: Path,
+    ref: str,
+    *,
+    run: Callable[..., subprocess.CompletedProcess[str]],
+) -> str | None:
+    """Capture one annotated-tag object identity from a mutable ref name.
+
+    Every later signature, commit, and tree lookup must use this immutable
+    object id.  Re-resolving ``ref`` after signature verification would let a
+    same-user process move the local tag between Git commands and lend the old
+    signature result to different bytes.
+    """
+    result = run(
+        ["git", "-C", str(root), "rev-parse", "--verify", f"{ref}^{{tag}}"],
+        capture_output=True,
+        text=True,
+        timeout=8.0,
+        check=False,
+    )
+    oid = result.stdout.strip()
+    if result.returncode != 0 or not re.fullmatch(r"[0-9a-f]{40,64}", oid):
+        return None
+    return oid
+
+
 def _containing_git_root(path: Path) -> Path | None:
     """Return the nearest repository root for a layer path.
 
@@ -298,9 +324,14 @@ def verify_git_item(
             )
             os.chmod(trust_file, 0o600)
 
+            tag_oid = _resolve_tag_object(root, ref, run=run)
+            if tag_oid is None:
+                return False, None
+
             # Step 1: the tag itself must carry a valid signature from an
-            # allowlisted signer. Stop here on any failure -- an unsigned or
-            # wrongly-signed tag never earns a tree lookup.
+            # allowlisted signer. Verify the captured tag OBJECT, not its
+            # mutable name. Stop here on any failure -- an unsigned or
+            # wrongly-signed object never earns a tree lookup.
             tag_result = run(
                 [
                     "git",
@@ -311,7 +342,7 @@ def verify_git_item(
                     "-C",
                     str(root),
                     "verify-tag",
-                    ref,
+                    tag_oid,
                 ],
                 capture_output=True,
                 text=True,
@@ -331,11 +362,10 @@ def verify_git_item(
                 # membership alone.
                 return False, fingerprint
 
-            # Step 2: resolve the SAME ref to the commit its signature
-            # covers -- never a second, independently-supplied commit -- so
-            # the tree check below is provably the tag's own target.
+            # Step 2: peel the SAME immutable tag object to the commit its
+            # signature covers. Never resolve the mutable ref name again.
             commit_result = run(
-                ["git", "-C", str(root), "rev-parse", f"{ref}^{{commit}}"],
+                ["git", "-C", str(root), "rev-parse", f"{tag_oid}^{{commit}}"],
                 capture_output=True,
                 text=True,
                 timeout=8.0,
@@ -431,6 +461,9 @@ def verify_git_item_provenance(
                 encoding="utf-8",
             )
             os.chmod(trust_file, 0o600)
+            tag_oid = _resolve_tag_object(root, ref, run=run)
+            if tag_oid is None:
+                return None
             tag = run(
                 [
                     "git",
@@ -441,7 +474,7 @@ def verify_git_item_provenance(
                     "-C",
                     str(root),
                     "verify-tag",
-                    ref,
+                    tag_oid,
                 ],
                 capture_output=True,
                 text=True,
@@ -454,7 +487,7 @@ def verify_git_item_provenance(
             if signer is None or _normalize_fingerprint(signer) not in allowed:
                 return None
             commit = run(
-                ["git", "-C", str(root), "rev-parse", f"{ref}^{{commit}}"],
+                ["git", "-C", str(root), "rev-parse", f"{tag_oid}^{{commit}}"],
                 capture_output=True,
                 text=True,
                 timeout=8.0,

--- a/tools/cc/src/cc/core/skill_store.py
+++ b/tools/cc/src/cc/core/skill_store.py
@@ -53,6 +53,7 @@ class SkillMeta:
     version: str = ""
     source: str = ""  # "project" | "machine" | "framework"
     extra: dict[str, Any] = field(default_factory=dict)
+    _knowledge_source: Any = field(default=None, repr=False, compare=False)
 
 
 def _git_root() -> Path | None:
@@ -85,14 +86,11 @@ def knowledge_skill_paths() -> list[Path]:
     "absent is a valid machine state" fail-open posture every other
     config-driven path in this codebase uses; never raises.
     """
-    from cc.core.config import resolve_knowledge_repos
+    from cc.core.ecosystem.knowledge_skill_source import (
+        resolve_knowledge_skill_sources,
+    )
 
-    paths: list[Path] = []
-    for repo in resolve_knowledge_repos():
-        skills_dir = Path(repo).expanduser() / _KNOWLEDGE_SKILLS_SUBPATH
-        if skills_dir.is_dir():
-            paths.append(skills_dir)
-    return paths
+    return [path for path, _source in resolve_knowledge_skill_sources()]
 
 
 def default_skill_paths() -> list[tuple[Path, str]]:
@@ -341,6 +339,7 @@ def discover_skills(
     source_label: str = "",
     *,
     cache_dir: Optional[Path] = None,
+    _knowledge_source: Any = None,
 ) -> list[SkillMeta]:
     """Scan each path for ``*/SKILL.md`` files and parse frontmatter.
 
@@ -370,10 +369,13 @@ def discover_skills(
         # Also supports nested: base/<category>/<name>/SKILL.md.
         # Follow symlinked directories so shared framework skills can be bridged
         # into project-local .claude/skills without copying the framework.
-        skill_files = []
-        for root, _dirs, files in os.walk(base, followlinks=True):
-            if "SKILL.md" in files:
-                skill_files.append(Path(root) / "SKILL.md")
+        if _knowledge_source is not None:
+            skill_files = list(_knowledge_source.skill_files())
+        else:
+            skill_files = []
+            for root, _dirs, files in os.walk(base, followlinks=True):
+                if "SKILL.md" in files:
+                    skill_files.append(Path(root) / "SKILL.md")
 
         for skill_file in sorted(skill_files):
             fm: Optional[dict[str, Any]] = None
@@ -394,7 +396,11 @@ def discover_skills(
 
             if fm is None:
                 try:
-                    text = _read_frontmatter_prefix(skill_file)
+                    text = (
+                        _knowledge_source.read_text(skill_file)
+                        if _knowledge_source is not None
+                        else _read_frontmatter_prefix(skill_file)
+                    )
                 except OSError:
                     continue
 
@@ -441,6 +447,7 @@ def discover_skills(
                     version=version,
                     source=source_label,
                     extra=extra,
+                    _knowledge_source=_knowledge_source,
                 )
             )
 
@@ -464,8 +471,29 @@ def discover_skills_with_sources(
     results: list[SkillMeta] = []
 
     for base_path, source_label in path_source_pairs:
+        knowledge_source = None
+        effective_cache_dir = cache_dir
+        if source_label == "knowledge":
+            from cc.core.ecosystem.knowledge_skill_source import (
+                resolve_knowledge_skill_sources,
+            )
+
+            nominal = Path(os.path.abspath(Path(base_path).expanduser()))
+            knowledge_source = next(
+                (
+                    source
+                    for root, source in resolve_knowledge_skill_sources()
+                    if root == nominal
+                ),
+                None,
+            )
+            # A mutable mtime/size cache is not an authority for signed bytes.
+            effective_cache_dir = None
         for skill in discover_skills(
-            [base_path], source_label=source_label, cache_dir=cache_dir
+            [base_path],
+            source_label=source_label,
+            cache_dir=effective_cache_dir,
+            _knowledge_source=knowledge_source,
         ):
             if skill.name not in seen_names:
                 seen_names.add(skill.name)
@@ -501,7 +529,25 @@ def search_skills(query: str, skills: list[SkillMeta]) -> list[SkillMeta]:
 
 def get_skill_content(skill_meta: SkillMeta) -> str:
     """Read and return the full SKILL.md content for a given skill."""
+    if skill_meta._knowledge_source is not None:
+        from cc.core.ecosystem.knowledge_skill_source import (
+            revalidate_knowledge_skill_source,
+        )
+
+        source = revalidate_knowledge_skill_source(skill_meta._knowledge_source)
+        return source.read_text(skill_meta.path)
     return skill_meta.path.read_text(encoding="utf-8")
+
+
+def revalidate_skill_path(skill_meta: SkillMeta) -> None:
+    """Revalidate signed Knowledge authority before disclosing a live path."""
+    if skill_meta._knowledge_source is None:
+        return
+    from cc.core.ecosystem.knowledge_skill_source import (
+        revalidate_knowledge_skill_source,
+    )
+
+    revalidate_knowledge_skill_source(skill_meta._knowledge_source)
 
 
 def find_skill_by_name(

--- a/tools/cc/tests/test_ecosystem_policy.py
+++ b/tools/cc/tests/test_ecosystem_policy.py
@@ -1,7 +1,15 @@
 import subprocess
 from pathlib import Path
 
-from cc.core.ecosystem.policy import evaluate, verify_git_item
+from cc.core.ecosystem.policy import (
+    evaluate,
+    read_git_tree_snapshot,
+    verify_git_item,
+    verify_git_item_provenance,
+)
+
+_TAG_OID = "a" * 40
+_COMMIT_OID = "b" * 40
 
 
 def test_non_executable_knowledge_does_not_require_code_signer():
@@ -28,6 +36,8 @@ def test_git_item_accepts_signed_tag_covering_item_in_its_tree(tmp_path):
 
     def fake(args, **kwargs):
         calls.append(list(args))
+        if args[-1].endswith("^{tag}"):
+            return subprocess.CompletedProcess(args, 0, f"{_TAG_OID}\n", "")
         if "verify-tag" in args:
             trust_arg = next(v for v in args if v.startswith("gpg.ssh.allowedSignersFile="))
             observed["trust"] = Path(trust_arg.split("=", 1)[1]).read_text(encoding="utf-8")
@@ -35,7 +45,7 @@ def test_git_item_accepts_signed_tag_covering_item_in_its_tree(tmp_path):
                 args, 0, "", 'Good "git" signature for enac-foundation with ED25519 key SHA256:ABC123\n'
             )
         if "rev-parse" in args:
-            return subprocess.CompletedProcess(args, 0, "deadbeefcafe1234\n", "")
+            return subprocess.CompletedProcess(args, 0, f"{_COMMIT_OID}\n", "")
         if "cat-file" in args:
             return subprocess.CompletedProcess(args, 0, "", "")
         raise AssertionError(f"unexpected git invocation: {args}")
@@ -51,25 +61,31 @@ def test_git_item_accepts_signed_tag_covering_item_in_its_tree(tmp_path):
 
     assert verified is True
     assert signer == "SHA256:ABC123"
-    assert len(calls) == 3
-    tag_call, rev_parse_call, cat_file_call = calls
+    assert len(calls) == 4
+    capture_call, tag_call, rev_parse_call, cat_file_call = calls
+
+    # Step 0: capture one immutable annotated-tag object identity from the
+    # mutable name. Every later command uses this object id.
+    assert capture_call == [
+        "git", "-C", str(tmp_path), "rev-parse", "--verify", "v5.13.23^{tag}",
+    ]
 
     # Step 1: the TAG itself is verified, using a trust file scoped to
     # exactly the compiled-key/manifest-signer intersection.
     assert observed["trust"] == (
         'enac-foundation namespaces="git" ssh-ed25519 AAAATESTKEY\n'
     )
-    assert tag_call[-2:] == ["verify-tag", "v5.13.23"]
+    assert tag_call[-2:] == ["verify-tag", _TAG_OID]
 
     # Step 2: the SAME ref is resolved to the commit its signature covers.
     assert rev_parse_call == [
-        "git", "-C", str(tmp_path), "rev-parse", "v5.13.23^{commit}",
+        "git", "-C", str(tmp_path), "rev-parse", f"{_TAG_OID}^{{commit}}",
     ]
 
     # Step 3: tree membership is checked at that resolved commit -- never a
     # `git log` walk.
     assert cat_file_call == [
-        "git", "-C", str(tmp_path), "cat-file", "-e", "deadbeefcafe1234:skills/review",
+        "git", "-C", str(tmp_path), "cat-file", "-e", f"{_COMMIT_OID}:skills/review",
     ]
 
 
@@ -82,6 +98,8 @@ def test_git_item_rejects_unsigned_or_wrongly_signed_tag(tmp_path):
 
     def fake(args, **kwargs):
         calls.append(list(args))
+        if args[-1].endswith("^{tag}"):
+            return subprocess.CompletedProcess(args, 0, f"{_TAG_OID}\n", "")
         return subprocess.CompletedProcess(args, 1, "", "No principal matched.\n")
 
     verified, signer = verify_git_item(
@@ -94,8 +112,8 @@ def test_git_item_rejects_unsigned_or_wrongly_signed_tag(tmp_path):
     )
 
     assert (verified, signer) == (False, None)
-    assert len(calls) == 1
-    assert calls[0][-2:] == ["verify-tag", "v5.13.23"]
+    assert len(calls) == 2
+    assert calls[1][-2:] == ["verify-tag", _TAG_OID]
 
 
 def test_git_item_rejects_valid_but_unapproved_signer(tmp_path):
@@ -107,6 +125,8 @@ def test_git_item_rejects_valid_but_unapproved_signer(tmp_path):
 
     def fake(args, **kwargs):
         calls.append(list(args))
+        if args[-1].endswith("^{tag}"):
+            return subprocess.CompletedProcess(args, 0, f"{_TAG_OID}\n", "")
         return subprocess.CompletedProcess(
             args, 0, "", 'Good "git" signature for x with ED25519 key SHA256:other\n'
         )
@@ -119,7 +139,7 @@ def test_git_item_rejects_valid_but_unapproved_signer(tmp_path):
         run=fake,
         _trusted_keys={"SHA256:approved": "ssh-ed25519 AAAAAPPROVED"},
     ) == (False, "SHA256:other")
-    assert len(calls) == 1
+    assert len(calls) == 2
 
 
 def test_git_item_rejects_manifest_fingerprint_not_compiled_into_cc(tmp_path):
@@ -168,6 +188,8 @@ def test_git_item_blocks_when_ref_does_not_resolve_after_signed_tag(tmp_path):
 
     def fake(args, **kwargs):
         calls.append(list(args))
+        if args[-1].endswith("^{tag}"):
+            return subprocess.CompletedProcess(args, 0, f"{_TAG_OID}\n", "")
         if "verify-tag" in args:
             return subprocess.CompletedProcess(
                 args, 0, "", 'Good "git" signature for x with ED25519 key SHA256:approved\n'
@@ -184,7 +206,7 @@ def test_git_item_blocks_when_ref_does_not_resolve_after_signed_tag(tmp_path):
         run=fake,
         _trusted_keys={"SHA256:approved": "ssh-ed25519 AAAAAPPROVED"},
     ) == (False, None)
-    assert len(calls) == 2
+    assert len(calls) == 3
 
 
 def test_git_item_blocks_when_item_missing_from_signed_tags_tree(tmp_path):
@@ -198,12 +220,14 @@ def test_git_item_blocks_when_item_missing_from_signed_tags_tree(tmp_path):
 
     def fake(args, **kwargs):
         calls.append(list(args))
+        if args[-1].endswith("^{tag}"):
+            return subprocess.CompletedProcess(args, 0, f"{_TAG_OID}\n", "")
         if "verify-tag" in args:
             return subprocess.CompletedProcess(
                 args, 0, "", 'Good "git" signature for x with ED25519 key SHA256:approved\n'
             )
         if "rev-parse" in args:
-            return subprocess.CompletedProcess(args, 0, "deadbeefcafe1234\n", "")
+            return subprocess.CompletedProcess(args, 0, f"{_COMMIT_OID}\n", "")
         if "cat-file" in args:
             return subprocess.CompletedProcess(
                 args, 128, "", "fatal: path 'skills/review' does not exist"
@@ -218,7 +242,7 @@ def test_git_item_blocks_when_item_missing_from_signed_tags_tree(tmp_path):
         run=fake,
         _trusted_keys={"SHA256:approved": "ssh-ed25519 AAAAAPPROVED"},
     ) == (False, None)
-    assert len(calls) == 3
+    assert len(calls) == 4
 
 
 def test_git_item_verifies_repo_relative_path_from_layer_subpath(tmp_path):
@@ -228,13 +252,15 @@ def test_git_item_verifies_repo_relative_path_from_layer_subpath(tmp_path):
     observed = {}
 
     def good(args, **kwargs):
+        if args[-1].endswith("^{tag}"):
+            return subprocess.CompletedProcess(args, 0, f"{_TAG_OID}\n", "")
         if "verify-tag" in args:
             observed["repo"] = args[args.index("-C") + 1]
             return subprocess.CompletedProcess(
                 args, 0, "", 'Good "git" signature for x with ED25519 key SHA256:approved\n'
             )
         if "rev-parse" in args:
-            return subprocess.CompletedProcess(args, 0, "deadbeefcafe1234\n", "")
+            return subprocess.CompletedProcess(args, 0, f"{_COMMIT_OID}\n", "")
         if "cat-file" in args:
             observed["path"] = args[-1]
             return subprocess.CompletedProcess(args, 0, "", "")
@@ -250,7 +276,7 @@ def test_git_item_verifies_repo_relative_path_from_layer_subpath(tmp_path):
     ) == (True, "SHA256:approved")
     assert observed == {
         "repo": str(tmp_path),
-        "path": "deadbeefcafe1234:.claude/commands/protocol.md",
+        "path": f"{_COMMIT_OID}:.claude/commands/protocol.md",
     }
 
 
@@ -369,3 +395,78 @@ def test_git_item_real_repro_still_blocks_genuinely_unsigned_tag(tmp_path):
         ref="v1.0.0",
         _trusted_keys={fingerprint: public_key},
     ) == (False, None)
+
+
+def test_provenance_binds_one_tag_object_across_ref_switch(tmp_path):
+    """A mutable tag name cannot lend its signature to replacement bytes."""
+    repo, fingerprint, public_key = _init_signing_repo(tmp_path)
+    skill = repo / "skills" / "review" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("signed bytes\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "--no-gpg-sign", "-m", "signed tree"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "tag", "-s", "v1.0.0", "-m", "signed release"],
+        cwd=repo,
+        check=True,
+    )
+    signed_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    skill.write_text("unsigned replacement bytes\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "--no-gpg-sign", "-m", "replacement"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "tag", "-a", "unsigned-replacement", "-m", "unsigned"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "checkout", "-q", "--detach", signed_commit], cwd=repo, check=True
+    )
+
+    switched = False
+
+    def switch_after_verification(args, **kwargs):
+        nonlocal switched
+        result = subprocess.run(args, **kwargs)
+        if not switched and "verify-tag" in args and result.returncode == 0:
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo),
+                    "update-ref",
+                    "refs/tags/v1.0.0",
+                    "refs/tags/unsigned-replacement",
+                ],
+                check=True,
+            )
+            switched = True
+        return result
+
+    proof = verify_git_item_provenance(
+        repo,
+        "skills/review",
+        [fingerprint],
+        ref="v1.0.0",
+        run=switch_after_verification,
+        _trusted_keys={fingerprint: public_key},
+    )
+    assert proof is not None
+    snapshot = read_git_tree_snapshot(repo, proof.tree)
+    assert snapshot is not None
+    assert [item.content for item in snapshot.files] == [b"signed bytes\n"]

--- a/tools/cc/tests/test_knowledge_skill_source.py
+++ b/tools/cc/tests/test_knowledge_skill_source.py
@@ -5,15 +5,22 @@ from __future__ import annotations
 import json
 import stat
 import subprocess
+import threading
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from cc.commands.deprovision import build_deprovision_report
+from cc.core.ecosystem import entitlement
 from cc.core.ecosystem.knowledge_skill_source import (
     KNOWLEDGE_SKILLS_SUBPATH,
     KnowledgeSkillSourceError,
+    prune_all_knowledge_snapshots,
     resolve_knowledge_skill_sources,
 )
+from cc.core.ecosystem.project_locking import atomic_json_write
 from cc.core.skill_store import (
+    discover_skills,
     discover_skills_with_sources,
     get_skill_content,
     revalidate_skill_path,
@@ -103,6 +110,56 @@ def signed_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         }.get(key),
     )
     return repo, fingerprint
+
+
+@pytest.fixture
+def protected_signed_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    repo, fingerprint, public_key = _signed_knowledge_repo(tmp_path)
+    layer = _layer(repo, fingerprint) | {
+        "role": "department",
+        "auth": "work",
+    }
+    state_path = tmp_path / "entitlements.json"
+    checked_at = (
+        datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    )
+    atomic_json_write(
+        state_path,
+        {
+            "schema_version": entitlement.ENTITLEMENT_SCHEMA_VERSION,
+            "next_sequence": 2,
+            "layers": {
+                "knowledge-test": {
+                    "layer": "knowledge-test",
+                    "product": "knowledge",
+                    "repo": "example/knowledge",
+                    "login": "person",
+                    "state": "entitled",
+                    "checked_at": checked_at,
+                    "last_entitled_at": checked_at,
+                    "revision": 1,
+                }
+            },
+        },
+    )
+    monkeypatch.setattr(
+        "cc.core.ecosystem.policy.FOUNDATION_SSH_SIGNING_KEYS",
+        {fingerprint: public_key},
+    )
+    monkeypatch.setattr("cc.core.config.resolve_knowledge_repos", lambda: [str(repo)])
+    monkeypatch.setattr(
+        "cc.core.config.resolve_key",
+        lambda key: {
+            "layers.manifest": [layer],
+            "paths.mirrors_root": str(tmp_path / "mirrors"),
+            "skills.cache_dir": str(tmp_path / "skill-cache"),
+        }.get(key),
+    )
+    monkeypatch.setattr("cc.core.ecosystem.entitlement.current_login", lambda: "person")
+    monkeypatch.setattr(
+        "cc.core.ecosystem.entitlement.entitlement_state_path", lambda: state_path
+    )
+    return repo, layer, state_path, tmp_path / "skill-cache" / "signed-knowledge-v1"
 
 
 def _discover_signed():
@@ -291,3 +348,401 @@ def test_cached_snapshot_tamper_fails_closed(signed_source):
 
     with pytest.raises(KnowledgeSkillSourceError, match="snapshot failed integrity"):
         resolve_knowledge_skill_sources()
+
+
+def test_public_signed_knowledge_is_account_free(
+    signed_source, monkeypatch: pytest.MonkeyPatch
+):
+    def unexpected_account_access():
+        raise AssertionError("public Knowledge consulted account state")
+
+    monkeypatch.setattr(
+        "cc.core.ecosystem.entitlement.current_login", unexpected_account_access
+    )
+    monkeypatch.setattr(
+        "cc.core.ecosystem.entitlement.entitlement_state_path",
+        unexpected_account_access,
+    )
+
+    skill = _discover_signed()
+    assert get_skill_content(skill).endswith("authorized body\n")
+
+
+def test_protected_index_is_private_token_free_and_revision_scoped(
+    protected_signed_source,
+):
+    _repo, _layer, state_path, cache_root = protected_signed_source
+    skill = _discover_signed()
+    index_path = cache_root / "index.json"
+    serialized = index_path.read_text(encoding="utf-8")
+    index = json.loads(serialized)
+    entry = next(iter(index["entries"].values()))
+
+    assert stat.S_IMODE(cache_root.stat().st_mode) == 0o700
+    assert stat.S_IMODE(index_path.stat().st_mode) == 0o600
+    assert "token" not in serialized.casefold()
+    assert entry["layer"] == "knowledge-test"
+    assert entry["repository"] == "example/knowledge"
+    assert entry["login"] == "person"
+    assert entry["revision"] == 1
+    assert entry["state_path"] == str(state_path)
+    assert entry["ref"] == "v1.0.0"
+    assert entry["tree"] == skill._knowledge_source.tree
+    assert all(
+        value not in entry["target"]
+        for value in ("knowledge-test", "example/knowledge", "person")
+    )
+
+
+@pytest.mark.parametrize(
+    ("login", "token", "status", "expected_state"),
+    [
+        ("person", "token", 404, "revoked"),
+        ("new-person", "token", 404, "unentitled"),
+        (None, None, None, "signed-out"),
+    ],
+)
+def test_protected_prior_path_is_pruned_on_terminal_observation(
+    protected_signed_source,
+    login: str | None,
+    token: str | None,
+    status: int | None,
+    expected_state: str,
+):
+    repo, layer, state_path, _cache_root = protected_signed_source
+    skill = _discover_signed()
+    stale_path = skill.path
+    assert stale_path.is_file()
+
+    decision = entitlement.observe_layer(
+        layer,
+        login=login,
+        token=token,
+        get_json=lambda *_args, **_kwargs: status,
+        state_path=state_path,
+    )
+
+    assert decision.state == expected_state
+    assert decision.eligible is False
+    assert not stale_path.exists()
+    with pytest.raises(FileNotFoundError):
+        stale_path.read_bytes()
+    if login == "new-person":
+        assert resolve_knowledge_skill_sources(entitlement_login=login) == []
+    else:
+        assert resolve_knowledge_skill_sources() == []
+    assert (repo / KNOWLEDGE_SKILLS_SUBPATH).is_dir()
+
+
+def test_offline_eligible_revision_retains_then_reauth_supersedes_snapshot(
+    protected_signed_source,
+):
+    _repo, layer, state_path, _cache_root = protected_signed_source
+    skill = _discover_signed()
+    prior_path = skill.path
+
+    offline = entitlement.observe_layer(
+        layer,
+        login="person",
+        token="token",
+        get_json=lambda *_args, **_kwargs: None,
+        state_path=state_path,
+    )
+    assert offline.state == "offline-cached"
+    assert offline.eligible is True
+    assert not prior_path.exists()
+    refreshed = _discover_signed()
+    assert refreshed.path != prior_path
+    assert refreshed.path.is_file()
+
+    live = entitlement.observe_layer(
+        layer,
+        login="person",
+        token="token",
+        get_json=lambda *_args, **_kwargs: 200,
+        state_path=state_path,
+    )
+    assert live.eligible is True
+    assert not refreshed.path.exists()
+
+
+def test_protected_read_and_revoke_serialize_without_partial_bytes(
+    protected_signed_source, monkeypatch: pytest.MonkeyPatch
+):
+    _repo, layer, state_path, _cache_root = protected_signed_source
+    skill = _discover_signed()
+    entered = threading.Event()
+    release = threading.Event()
+    original = skill._knowledge_source.snapshot.files[0].content
+
+    from cc.core.ecosystem import knowledge_skill_source as source_module
+
+    real_read = source_module._read_private_file
+
+    def delayed_read(path, *, expected_mode):
+        entered.set()
+        assert release.wait(timeout=5)
+        return real_read(path, expected_mode=expected_mode)
+
+    monkeypatch.setattr(source_module, "_read_private_file", delayed_read)
+    result: list[str] = []
+
+    reader = threading.Thread(target=lambda: result.append(skill._knowledge_source.read_text(skill.path)))
+    reader.start()
+    assert entered.wait(timeout=5)
+
+    revoke_done = threading.Event()
+
+    def revoke():
+        entitlement.observe_layer(
+            layer,
+            login="person",
+            token="token",
+            get_json=lambda *_args, **_kwargs: 404,
+            state_path=state_path,
+        )
+        revoke_done.set()
+
+    revoker = threading.Thread(target=revoke)
+    revoker.start()
+    assert not revoke_done.wait(timeout=0.1)
+    release.set()
+    reader.join(timeout=5)
+    revoker.join(timeout=5)
+
+    assert result and result[0].encode("utf-8") == original
+    assert revoke_done.is_set()
+    assert not skill.path.exists()
+
+
+def test_superseded_offline_observation_cannot_restore_revoked_snapshot(
+    protected_signed_source,
+):
+    _repo, layer, state_path, _cache_root = protected_signed_source
+    skill = _discover_signed()
+    stale_path = skill.path
+    entered = threading.Event()
+    release = threading.Event()
+    results: list[entitlement.EntitlementDecision] = []
+
+    def delayed_offline(_url, _token):
+        entered.set()
+        assert release.wait(timeout=5)
+        return None
+
+    old = threading.Thread(
+        target=lambda: results.append(
+            entitlement.observe_layer(
+                layer,
+                login="person",
+                token="token",
+                get_json=delayed_offline,
+                state_path=state_path,
+            )
+        )
+    )
+    old.start()
+    assert entered.wait(timeout=5)
+    revoked = entitlement.observe_layer(
+        layer,
+        login="person",
+        token="token",
+        get_json=lambda *_args, **_kwargs: 404,
+        state_path=state_path,
+    )
+    assert revoked.state == "revoked"
+    assert not stale_path.exists()
+
+    release.set()
+    old.join(timeout=5)
+    assert results and results[0].superseded is True
+    assert results[0].eligible is False
+    assert not stale_path.exists()
+    assert resolve_knowledge_skill_sources() == []
+
+
+def test_superseded_old_identity_cannot_prune_new_reauthorization(
+    protected_signed_source,
+):
+    _repo, layer, state_path, _cache_root = protected_signed_source
+    old_skill = _discover_signed()
+    entered = threading.Event()
+    release = threading.Event()
+    results: list[entitlement.EntitlementDecision] = []
+
+    def delayed_denial(_url, _token):
+        entered.set()
+        assert release.wait(timeout=5)
+        return 404
+
+    old = threading.Thread(
+        target=lambda: results.append(
+            entitlement.observe_layer(
+                layer,
+                login="person",
+                token="token",
+                get_json=delayed_denial,
+                state_path=state_path,
+            )
+        )
+    )
+    old.start()
+    assert entered.wait(timeout=5)
+    reauthorized = entitlement.observe_layer(
+        layer,
+        login="new-person",
+        token="token",
+        get_json=lambda *_args, **_kwargs: 200,
+        state_path=state_path,
+    )
+    assert reauthorized.eligible is True
+    assert not old_skill.path.exists()
+    pairs = resolve_knowledge_skill_sources(entitlement_login="new-person")
+    new_skill = discover_skills(
+        [pairs[0][0]],
+        source_label="knowledge",
+        _knowledge_source=pairs[0][1],
+    )[0]
+    assert new_skill.path.is_file()
+
+    release.set()
+    old.join(timeout=5)
+    assert results and results[0].superseded is True
+    assert results[0].eligible is True
+    assert new_skill.path.is_file()
+
+
+def test_hard_prune_recovers_pending_and_removes_indexed_snapshots(
+    protected_signed_source,
+):
+    _repo, _layer, _state_path, cache_root = protected_signed_source
+    skill = _discover_signed()
+    assert skill.path.exists()
+    assert prune_all_knowledge_snapshots(cache_root=cache_root) == 1
+    assert not skill.path.exists()
+    index = json.loads((cache_root / "index.json").read_text(encoding="utf-8"))
+    assert index["entries"] == {}
+
+
+def test_interrupted_publication_is_recovered_without_reviving_path(
+    protected_signed_source,
+):
+    _repo, _layer, _state_path, cache_root = protected_signed_source
+    skill = _discover_signed()
+    index_path = cache_root / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    entry = next(iter(index["entries"].values()))
+    entry["status"] = "pending"
+    atomic_json_write(index_path, index)
+
+    assert prune_all_knowledge_snapshots(cache_root=cache_root) == 0
+    assert not skill.path.exists()
+    recovered = json.loads(index_path.read_text(encoding="utf-8"))
+    assert recovered["entries"] == {}
+
+
+def test_symlinked_snapshot_index_fails_closed_and_preserves_outside(
+    protected_signed_source,
+):
+    _repo, _layer, _state_path, cache_root = protected_signed_source
+    skill = _discover_signed()
+    index_path = cache_root / "index.json"
+    outside = cache_root.parent / "outside-index.json"
+    outside.write_text(index_path.read_text(encoding="utf-8"), encoding="utf-8")
+    index_path.unlink()
+    index_path.symlink_to(outside)
+
+    with pytest.raises(KnowledgeSkillSourceError, match="index is unsafe"):
+        prune_all_knowledge_snapshots(cache_root=cache_root)
+    # Hard-prune rejects corrupted metadata without following the link.  The
+    # entitlement path uses the protected-only emergency invalidation below.
+    assert skill.path.exists()
+    assert outside.is_file()
+
+    with pytest.raises(KnowledgeSkillSourceError, match="index is unsafe"):
+        entitlement.observe_layer(
+            protected_signed_source[1],
+            login="person",
+            token="token",
+            get_json=lambda *_args, **_kwargs: 404,
+            state_path=protected_signed_source[2],
+        )
+    assert not skill.path.exists()
+    assert outside.is_file()
+
+
+def test_revocation_unlinks_replaced_snapshot_without_following_it(
+    protected_signed_source,
+):
+    _repo, layer, state_path, cache_root = protected_signed_source
+    skill = _discover_signed()
+    snapshot_root = skill._knowledge_source.skills_root
+    outside = cache_root.parent / "outside-protected-tree"
+    snapshot_root.rename(outside)
+    snapshot_root.symlink_to(outside, target_is_directory=True)
+    assert skill.path.is_file()
+
+    decision = entitlement.observe_layer(
+        layer,
+        login="person",
+        token="token",
+        get_json=lambda *_args, **_kwargs: 404,
+        state_path=state_path,
+    )
+
+    assert decision.state == "revoked"
+    assert not snapshot_root.exists()
+    assert not snapshot_root.is_symlink()
+    assert (outside / "accounting" / "SKILL.md").is_file()
+
+
+def test_protected_revocation_preserves_account_free_public_snapshot(
+    protected_signed_source, monkeypatch: pytest.MonkeyPatch
+):
+    repo, protected_layer, state_path, _cache_root = protected_signed_source
+    protected_skill = _discover_signed()
+    public_layer = protected_layer | {"role": "personal", "auth": "anon"}
+    monkeypatch.setattr(
+        "cc.core.config.resolve_key",
+        lambda key: {
+            "layers.manifest": [public_layer],
+            "paths.mirrors_root": str(repo.parent / "mirrors"),
+            "skills.cache_dir": str(repo.parent / "skill-cache"),
+        }.get(key),
+    )
+    public_skill = _discover_signed()
+    assert public_skill.path != protected_skill.path
+
+    entitlement.observe_layer(
+        protected_layer,
+        login="person",
+        token="token",
+        get_json=lambda *_args, **_kwargs: 404,
+        state_path=state_path,
+    )
+
+    assert not protected_skill.path.exists()
+    assert public_skill.path.is_file()
+    assert public_skill.path.read_text(encoding="utf-8").endswith("authorized body\n")
+
+
+def test_hard_deprovision_prunes_exact_index_and_preserves_unrelated_cache(
+    protected_signed_source,
+):
+    _repo, _layer, _state_path, cache_root = protected_signed_source
+    skill = _discover_signed()
+    unrelated = cache_root / "not-framework-owned.txt"
+    unrelated.write_text("keep", encoding="utf-8")
+
+    report = build_deprovision_report(
+        _lockfile_path=cache_root.parent / "missing.lock.json",
+        _mirror_root=cache_root.parent / "mirrors",
+        _materialize_root=cache_root.parent / "materialized",
+        _knowledge_snapshot_root=cache_root,
+        _mode="hard",
+        _personal_roots=[],
+    )
+
+    assert report["removed"]["materialized"] == 1
+    assert not skill.path.exists()
+    assert unrelated.read_text(encoding="utf-8") == "keep"

--- a/tools/cc/tests/test_knowledge_skill_source.py
+++ b/tools/cc/tests/test_knowledge_skill_source.py
@@ -1,0 +1,242 @@
+"""Signed, immutable Knowledge skill read enforcement."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from cc.core.ecosystem.knowledge_skill_source import (
+    KNOWLEDGE_SKILLS_SUBPATH,
+    KnowledgeSkillSourceError,
+    resolve_knowledge_skill_sources,
+)
+from cc.core.skill_store import (
+    discover_skills_with_sources,
+    get_skill_content,
+    revalidate_skill_path,
+)
+from cc.main import app
+from typer.testing import CliRunner
+
+
+def _run(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _signed_knowledge_repo(tmp_path: Path) -> tuple[Path, str, str]:
+    repo = tmp_path / "knowledge"
+    repo.mkdir()
+    key = tmp_path / "release-key"
+    subprocess.run(
+        ["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(key)],
+        check=True,
+    )
+    fingerprint = subprocess.run(
+        ["ssh-keygen", "-lf", f"{key}.pub", "-E", "sha256"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()[1]
+    public_key = " ".join(
+        key.with_suffix(".pub").read_text(encoding="utf-8").split()[:2]
+    )
+    for args in (
+        ("init", "-q"),
+        ("config", "user.name", "Knowledge Release Test"),
+        ("config", "user.email", "knowledge@example.invalid"),
+        ("config", "gpg.format", "ssh"),
+        ("config", "user.signingkey", str(key)),
+        ("remote", "add", "origin", "git@github.com:example/knowledge.git"),
+    ):
+        _run(repo, *args)
+    skill = repo / KNOWLEDGE_SKILLS_SUBPATH / "accounting" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text(
+        "---\nname: accounting\ndescription: Signed accounting knowledge\n"
+        "tags: [accounting]\n---\n\nauthorized body\n",
+        encoding="utf-8",
+    )
+    _run(repo, "add", ".")
+    _run(repo, "commit", "-q", "--no-gpg-sign", "-m", "knowledge")
+    _run(repo, "tag", "-s", "v1.0.0", "-m", "release")
+    return repo, fingerprint, public_key
+
+
+def _layer(repo: Path, fingerprint: str, *, ref: str = "v1.0.0") -> dict:
+    return {
+        "id": "knowledge-test",
+        "role": "personal",
+        "rank": 10,
+        "product": "knowledge",
+        "source": {
+            "repo": "git@github.com:example/knowledge.git",
+            "ref": ref,
+            "path": str(repo),
+        },
+        "auth": "anon",
+        "activation": "always",
+        "policy": {"allowed_signers": [fingerprint]},
+    }
+
+
+@pytest.fixture
+def signed_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    repo, fingerprint, public_key = _signed_knowledge_repo(tmp_path)
+    monkeypatch.setattr(
+        "cc.core.ecosystem.policy.FOUNDATION_SSH_SIGNING_KEYS",
+        {fingerprint: public_key},
+    )
+    monkeypatch.setattr(
+        "cc.core.config.resolve_knowledge_repos", lambda: [str(repo)]
+    )
+    monkeypatch.setattr(
+        "cc.core.config.resolve_key",
+        lambda key: {
+            "layers.manifest": [_layer(repo, fingerprint)],
+            "paths.mirrors_root": str(tmp_path / "mirrors"),
+        }.get(key),
+    )
+    return repo, fingerprint
+
+
+def _discover_signed():
+    pairs = resolve_knowledge_skill_sources()
+    skills = discover_skills_with_sources([(pairs[0][0], "knowledge")])
+    assert len(skills) == 1
+    return skills[0]
+
+
+def test_signed_tree_drives_discovery_and_get(signed_source):
+    skill = _discover_signed()
+    assert skill.name == "accounting"
+    assert get_skill_content(skill).endswith("authorized body\n")
+    revalidate_skill_path(skill)
+
+
+def test_tracked_mutation_fails_closed_before_discovery(signed_source):
+    repo, _fingerprint = signed_source
+    (repo / KNOWLEDGE_SKILLS_SUBPATH / "accounting" / "SKILL.md").write_text(
+        "malicious working-tree body\n", encoding="utf-8"
+    )
+    with pytest.raises(KnowledgeSkillSourceError, match="signed release"):
+        resolve_knowledge_skill_sources()
+
+
+def test_untracked_and_ignored_additions_fail_closed(signed_source):
+    repo, _fingerprint = signed_source
+    injected = repo / KNOWLEDGE_SKILLS_SUBPATH / "injected" / "SKILL.md"
+    injected.parent.mkdir()
+    injected.write_text("untracked injection\n", encoding="utf-8")
+    with pytest.raises(KnowledgeSkillSourceError, match="signed release"):
+        resolve_knowledge_skill_sources()
+    injected.unlink()
+    (repo / ".gitignore").write_text(
+        f"/{KNOWLEDGE_SKILLS_SUBPATH}/injected/\n", encoding="utf-8"
+    )
+    _run(repo, "add", ".gitignore")
+    _run(repo, "commit", "-q", "--no-gpg-sign", "-m", "ignore rule after release")
+    injected.write_text("ignored injection\n", encoding="utf-8")
+    with pytest.raises(KnowledgeSkillSourceError, match="signed release|ignored local additions"):
+        resolve_knowledge_skill_sources()
+
+
+def test_wrong_ref_signer_and_origin_fail_closed(
+    signed_source, monkeypatch: pytest.MonkeyPatch
+):
+    repo, fingerprint = signed_source
+    config = {
+        "layers.manifest": [_layer(repo, fingerprint, ref="missing")],
+        "paths.mirrors_root": str(repo.parent / "mirrors"),
+    }
+    monkeypatch.setattr("cc.core.config.resolve_key", lambda key: config.get(key))
+    with pytest.raises(KnowledgeSkillSourceError, match="signed release"):
+        resolve_knowledge_skill_sources()
+
+    config["layers.manifest"] = [_layer(repo, "SHA256:not-compiled")]
+    with pytest.raises(KnowledgeSkillSourceError, match="signed release"):
+        resolve_knowledge_skill_sources()
+
+    config["layers.manifest"] = [_layer(repo, fingerprint)]
+    _run(repo, "remote", "set-url", "origin", "git@github.com:other/repo.git")
+    with pytest.raises(KnowledgeSkillSourceError, match="wrong repository origin"):
+        resolve_knowledge_skill_sources()
+
+
+def test_unsigned_tag_and_symlinked_item_fail_closed(
+    signed_source, monkeypatch: pytest.MonkeyPatch
+):
+    repo, fingerprint = signed_source
+    _run(repo, "tag", "unsigned")
+    monkeypatch.setattr(
+        "cc.core.config.resolve_key",
+        lambda key: {
+            "layers.manifest": [_layer(repo, fingerprint, ref="unsigned")],
+            "paths.mirrors_root": str(repo.parent / "mirrors"),
+        }.get(key),
+    )
+    with pytest.raises(KnowledgeSkillSourceError, match="signed release"):
+        resolve_knowledge_skill_sources()
+
+    monkeypatch.setattr(
+        "cc.core.config.resolve_key",
+        lambda key: {
+            "layers.manifest": [_layer(repo, fingerprint)],
+            "paths.mirrors_root": str(repo.parent / "mirrors"),
+        }.get(key),
+    )
+    target = repo / KNOWLEDGE_SKILLS_SUBPATH / "accounting" / "SKILL.md"
+    original = target.read_text(encoding="utf-8")
+    target.unlink()
+    outside = repo.parent / "outside-skill"
+    outside.write_text(original, encoding="utf-8")
+    target.symlink_to(outside)
+    with pytest.raises(KnowledgeSkillSourceError, match="signed release"):
+        resolve_knowledge_skill_sources()
+
+
+def test_symlinked_skill_ancestor_fails_closed(signed_source):
+    repo, _fingerprint = signed_source
+    skill_dir = repo / KNOWLEDGE_SKILLS_SUBPATH / "accounting"
+    content = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    (skill_dir / "SKILL.md").unlink()
+    skill_dir.rmdir()
+    outside = repo.parent / "outside-accounting"
+    outside.mkdir()
+    (outside / "SKILL.md").write_text(content, encoding="utf-8")
+    skill_dir.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(KnowledgeSkillSourceError, match="signed release"):
+        resolve_knowledge_skill_sources()
+
+
+def test_mutation_after_discovery_blocks_get_and_path(signed_source):
+    repo, _fingerprint = signed_source
+    skill = _discover_signed()
+    skill.path.write_text("changed after selection\n", encoding="utf-8")
+    with pytest.raises(KnowledgeSkillSourceError):
+        get_skill_content(skill)
+    with pytest.raises(KnowledgeSkillSourceError):
+        revalidate_skill_path(skill)
+
+
+@pytest.mark.parametrize(
+    ("arguments", "forbidden"),
+    [
+        (["skill", "search", "accounting"], "changed after selection"),
+        (["skill", "get", "accounting"], "changed after selection"),
+        (["skill", "path", "accounting"], KNOWLEDGE_SKILLS_SUBPATH),
+    ],
+)
+def test_cli_search_get_and_path_fail_closed_on_mutable_tamper(
+    signed_source, arguments: list[str], forbidden: str
+):
+    repo, _fingerprint = signed_source
+    (repo / KNOWLEDGE_SKILLS_SUBPATH / "accounting" / "SKILL.md").write_text(
+        "changed after selection\n", encoding="utf-8"
+    )
+    result = CliRunner().invoke(app, arguments)
+    assert result.exit_code == 1
+    assert "do not match their signed release" in result.output
+    assert forbidden not in result.output

--- a/tools/cc/tests/test_knowledge_skill_source.py
+++ b/tools/cc/tests/test_knowledge_skill_source.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import stat
 import subprocess
 from pathlib import Path
 
@@ -97,6 +99,7 @@ def signed_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         lambda key: {
             "layers.manifest": [_layer(repo, fingerprint)],
             "paths.mirrors_root": str(tmp_path / "mirrors"),
+            "skills.cache_dir": str(tmp_path / "skill-cache"),
         }.get(key),
     )
     return repo, fingerprint
@@ -110,9 +113,13 @@ def _discover_signed():
 
 
 def test_signed_tree_drives_discovery_and_get(signed_source):
+    repo, _fingerprint = signed_source
     skill = _discover_signed()
     assert skill.name == "accounting"
     assert get_skill_content(skill).endswith("authorized body\n")
+    assert repo not in skill.path.parents
+    assert stat.S_IMODE(skill.path.stat().st_mode) == 0o400
+    assert stat.S_IMODE(skill.path.parent.stat().st_mode) == 0o500
     revalidate_skill_path(skill)
 
 
@@ -214,7 +221,8 @@ def test_symlinked_skill_ancestor_fails_closed(signed_source):
 def test_mutation_after_discovery_blocks_get_and_path(signed_source):
     repo, _fingerprint = signed_source
     skill = _discover_signed()
-    skill.path.write_text("changed after selection\n", encoding="utf-8")
+    checkout_skill = repo / KNOWLEDGE_SKILLS_SUBPATH / "accounting" / "SKILL.md"
+    checkout_skill.write_text("changed after selection\n", encoding="utf-8")
     with pytest.raises(KnowledgeSkillSourceError):
         get_skill_content(skill)
     with pytest.raises(KnowledgeSkillSourceError):
@@ -240,3 +248,46 @@ def test_cli_search_get_and_path_fail_closed_on_mutable_tamper(
     assert result.exit_code == 1
     assert "do not match their signed release" in result.output
     assert forbidden not in result.output
+
+
+def test_path_returns_immutable_snapshot_not_mutable_checkout(signed_source):
+    repo, _fingerprint = signed_source
+    result = CliRunner().invoke(
+        app, ["skill", "path", "accounting", "--scope", "knowledge"]
+    )
+    assert result.exit_code == 0, result.output
+    emitted = Path(result.output.strip())
+    assert repo not in emitted.parents
+
+    checkout_skill = repo / KNOWLEDGE_SKILLS_SUBPATH / "accounting" / "SKILL.md"
+    checkout_skill.write_text("attacker bytes after path return\n", encoding="utf-8")
+
+    assert emitted.read_text(encoding="utf-8").endswith("authorized body\n")
+    assert "attacker bytes" not in emitted.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["skill", "list", "--scope", "knowledge", "--json"],
+        ["skill", "search", "accounting", "--scope", "knowledge", "--json"],
+    ],
+)
+def test_path_bearing_json_uses_snapshot_not_checkout(
+    signed_source, arguments: list[str]
+):
+    repo, _fingerprint = signed_source
+    result = CliRunner().invoke(app, arguments)
+    assert result.exit_code == 0, result.output
+    path = Path(json.loads(result.output)[0]["path"])
+    assert repo not in path.parents
+    assert path.read_text(encoding="utf-8").endswith("authorized body\n")
+
+
+def test_cached_snapshot_tamper_fails_closed(signed_source):
+    skill = _discover_signed()
+    skill.path.chmod(0o600)
+    skill.path.write_text("tampered cached bytes\n", encoding="utf-8")
+
+    with pytest.raises(KnowledgeSkillSourceError, match="snapshot failed integrity"):
+        resolve_knowledge_skill_sources()


### PR DESCRIPTION
Closes the runtime enforcement gap identified in TASK-297 / WP-755.

## What changed
- bind configured Knowledge repositories to one eligible effective Knowledge layer by nominal path and canonical GitHub origin
- require a signed annotated immutable ref whose signer is both manifest-allowed and compiled into cc
- verify the exact `03-ai-enabling/01-skills` tree and reject tracked, untracked, ignored, symlinked, wrong-origin, wrong-ref, and wrong-signer sources
- enumerate and read `SKILL.md` from authenticated Git object bytes rather than mutable checkout bytes
- revalidate provenance immediately before `skill get` content reads and `skill path` disclosure
- preserve legacy configured Knowledge repositories only when no matching signed layer declares trust policy

## Evidence
- focused Knowledge + legacy skills: 73 passed
- full `tools/cc` non-machine suite: passed
- live signed accounting resolution: `throughput-accounting` resolved
- ruff, py_compile, and diff checks: passed
- commit `5b5a2d5ec2e5cfe9e45b75450c715cebce008b2a` signed by pinned Foundation authority; hosted Actions are intentionally disabled for maintenance

## Boundary
No content repository, manifest, entitlement ledger, tag, release, or Actions setting changed. Do not merge until independent QA/security and maintenance-mode CI restoration.