### PR TITLE
Reprove live resolution provenance

### DIFF
--- a/tools/cc/src/cc/commands/resolve.py
+++ b/tools/cc/src/cc/commands/resolve.py
@@ -11,11 +11,10 @@ Contract sources:
     test)
 
 READ-ONLY: this module never acquires the copilot lock (core/locking.py)
-and never materializes/writes anything. It only (in order): loads the
-layer manifest, best-effort-discovers local layer content
-(core/ecosystem/discovery.py), reads (never writes) the lockfile
-(core/ecosystem/lockfile.py), and folds the PURE resolver
-(core/ecosystem/resolver.py) over the result.
+and never materializes/writes anything. It loads the layer manifest,
+best-effort-discovers local layer content, reads the lockfile, folds the
+PURE resolver, then re-proves signed-source and materialized-byte evidence
+without changing any receipt, cache, lock, or destination.
 
 Naming note: `cc resolve` already existed as a single-config-key resolver
 (`cc resolve paths.shared_docs`). Per the same WS-A naming precedent as
@@ -27,12 +26,13 @@ argument was given: `cc resolve <key>` keeps its pre-existing behavior;
 `resolve_cmd` for the dispatch and a note on why this collision was
 resolved this way rather than by renaming either verb.
 
-Fail-closed security fields (deferred to later slices): every item always
-emits `signer_of_introducing_commit: null` and `live_hash_matches: false`.
-These become real once signature-verify (a policy module, ecosystem-
-architecture.md §7.2/§9) and materialize (§3.2) land. NEVER fabricate a
-"signed"/"matches" verdict before those modules exist — see
-core/ecosystem/resolver.py's `_make_item()`.
+Fail-closed security fields are enriched only here, at the I/O boundary.
+The pure resolver still defaults them to null/false. A signer is emitted
+only after the winning item is reverified against its immutable signed tag;
+`live_hash_matches` becomes true only when the destination's freshly computed
+canonical content hash equals the winning lock pin. Protected Knowledge uses
+its private active receipt and signed Git-object projection as authority,
+never mutable checkout bytes.
 """
 
 from __future__ import annotations
@@ -41,10 +41,18 @@ from pathlib import Path
 from typing import Any, Optional
 
 from cc.core.config import resolve_key
-from cc.core.ecosystem import mirror
+from cc.core.ecosystem import entitlement, mirror
 from cc.core.ecosystem.discovery import discover_contributions
+from cc.core.ecosystem.knowledge_skill_source import (
+    inspect_protected_knowledge_lock_projection,
+)
 from cc.core.ecosystem.lockfile import default_lockfile_path, read_lockfile
 from cc.core.ecosystem.manifest import load_layers, validate_layers
+from cc.core.ecosystem.materialize import (
+    content_item_path,
+    materialized_item_content_sha,
+)
+from cc.core.ecosystem.policy import verify_git_item
 from cc.core.ecosystem.resolver import resolve_layers
 
 SCHEMA_VERSION = "1.0"
@@ -85,6 +93,112 @@ def _synthesize_effective_layers(
     return mirror.synthesize_effective_layers(layers, mirror_root_base=mirror_root_base)
 
 
+def _resolved_materialize_roots(
+    injected: Any,
+) -> dict[str, Path]:
+    if injected is not _UNSET:
+        return {
+            str(product): Path(path).expanduser()
+            for product, path in injected.items()
+        }
+    generic_value = resolve_key("paths.materialize_root")
+    claude_value = resolve_key("paths.claude_materialize_root")
+    codex_value = resolve_key("paths.codex_materialize_root")
+    generic = Path(str(generic_value)).expanduser() if generic_value else None
+    roots: dict[str, Path] = {}
+    if claude_value:
+        roots["claude"] = Path(str(claude_value)).expanduser()
+    elif generic is not None:
+        roots["claude"] = generic
+    if codex_value:
+        roots["codex"] = Path(str(codex_value)).expanduser()
+    elif generic is not None:
+        roots["codex"] = generic / "codex"
+    return roots
+
+
+def _enrich_provenance(
+    items: list[dict[str, Any]],
+    layers: list[dict[str, Any]],
+    *,
+    materialize_roots: dict[str, Path],
+    knowledge_cache_root: Path | str | None,
+) -> None:
+    """Mutate resolver result dictionaries with freshly re-proved evidence."""
+    layer_by_id = {str(layer["id"]): layer for layer in layers}
+    knowledge_projection_by_layer: dict[str, Any] = {}
+    for entry in items:
+        layer_id = str(entry.get("winning_layer") or "")
+        layer = layer_by_id.get(layer_id)
+        if layer is None:
+            continue
+
+        if layer.get("product") == "knowledge" and entitlement.is_protected_layer(
+            layer
+        ):
+            if layer_id not in knowledge_projection_by_layer:
+                knowledge_projection_by_layer[layer_id] = (
+                    inspect_protected_knowledge_lock_projection(
+                        layer, cache_root=knowledge_cache_root
+                    )
+                )
+            projection = knowledge_projection_by_layer[layer_id]
+            if (
+                projection is not None
+                and entry.get("dimension") == projection.dimension
+                and entry.get("item") == projection.item
+            ):
+                entry["signer_of_introducing_commit"] = projection.signer
+                entry["live_hash_matches"] = bool(
+                    entry.get("winning_sha")
+                    and entry["winning_sha"] == projection.content_sha256
+                )
+            continue
+
+        source = layer.get("source") or {}
+        source_root = source.get("path")
+        source_ref = source.get("ref")
+        policy = layer.get("policy")
+        signers = policy.get("allowed_signers") if isinstance(policy, dict) else None
+        if (
+            isinstance(source_root, str)
+            and isinstance(source_ref, str)
+            and isinstance(signers, list)
+            and signers
+        ):
+            source_item = content_item_path(
+                source_root,
+                dimension=str(entry["dimension"]),
+                item=str(entry["item"]),
+            )
+            if source_item is not None:
+                try:
+                    relative_path = source_item.relative_to(
+                        Path(source_root).expanduser()
+                    ).as_posix()
+                except ValueError:
+                    relative_path = ""
+                if relative_path:
+                    verified, signer = verify_git_item(
+                        source_root,
+                        relative_path,
+                        signers,
+                        ref=source_ref,
+                    )
+                    if verified and signer:
+                        entry["signer_of_introducing_commit"] = signer
+
+        winning_sha = entry.get("winning_sha")
+        if isinstance(winning_sha, str) and winning_sha:
+            live_sha = materialized_item_content_sha(
+                product=str(entry.get("product") or ""),
+                dimension=str(entry["dimension"]),
+                item=str(entry["item"]),
+                materialize_roots=materialize_roots,
+            )
+            entry["live_hash_matches"] = live_sha == winning_sha
+
+
 def build_resolve_report(
     *,
     _layers: Optional[list[dict[str, Any]]] = None,
@@ -93,6 +207,8 @@ def build_resolve_report(
     _manifest_path: Any = _UNSET,
     _lockfile_path: Any = _UNSET,
     _mirror_root: Any = _UNSET,
+    _materialize_roots: Any = _UNSET,
+    _knowledge_cache_root: Any = _UNSET,
 ) -> dict[str, Any]:
     """
     Build the WS-A `resolve --explain --json` contract object.
@@ -150,6 +266,14 @@ def build_resolve_report(
         lockfile = read_lockfile(lockfile_path)
 
     items = resolve_layers(effective_layers, contributions, lockfile=lockfile)
+    _enrich_provenance(
+        items,
+        effective_layers,
+        materialize_roots=_resolved_materialize_roots(_materialize_roots),
+        knowledge_cache_root=(
+            None if _knowledge_cache_root is _UNSET else _knowledge_cache_root
+        ),
+    )
     return {"schema_version": SCHEMA_VERSION, "items": items}
 
 
@@ -183,8 +307,14 @@ def render_resolve_report_rich(report: dict[str, Any], *, console: Any = None) -
             con.print(
                 f"    shadows {shadow.get('layer')} (rank {shadow.get('rank')}){stale_note}"
             )
+        signer = entry.get("signer_of_introducing_commit")
+        if signer:
+            con.print(f"    signer: {signer}")
         if entry.get("live_hash_matches") is False:
-            con.print(
-                "    [yellow]live_hash_matches: false — unverified "
-                "(signature-verify not implemented yet)[/yellow]"
-            )
+            if entry.get("winning_sha"):
+                con.print(
+                    "    [red]MODIFIED — on-disk content no longer matches "
+                    "the recorded SHA[/red]"
+                )
+            else:
+                con.print("    [yellow]no recorded SHA is available[/yellow]")

--- a/tools/cc/src/cc/core/ecosystem/knowledge_skill_source.py
+++ b/tools/cc/src/cc/core/ecosystem/knowledge_skill_source.py
@@ -31,6 +31,7 @@ from cc.core.ecosystem.policy import (
     VerifiedSignedRelease,
     read_git_tree_snapshot,
     verify_git_item_provenance,
+    verify_git_tree_release,
 )
 from cc.core.ecosystem.project_locking import (
     UnsafeProjectPath,
@@ -1221,6 +1222,174 @@ def resolve_protected_knowledge_lock_projections(
                 )
             )
     return tuple(projections)
+
+
+def inspect_protected_knowledge_lock_projection(
+    layer: dict[str, Any],
+    *,
+    cache_root: Path | str | None = None,
+) -> ProtectedKnowledgeLockProjection | None:
+    """Read and re-prove one protected Knowledge plugin lock projection.
+
+    Unlike ``resolve_protected_knowledge_lock_projections()``, this inspector
+    never rolls a receipt, writes the index, creates a cache directory, or
+    consults the network.  It accepts evidence only when one active private
+    receipt still matches the signed skills tree byte-for-byte and the plugin
+    projection is derived from the same verified immutable release.
+    """
+    if layer.get("product") != "knowledge" or not entitlement.is_protected_layer(
+        layer
+    ):
+        return None
+    layer_id = str(layer.get("id") or "")
+    source = layer.get("source") or {}
+    source_root = source.get("path")
+    ref = source.get("ref")
+    repository = repository_identity(source.get("repo"))
+    try:
+        signers = _signed_policy(layer)
+    except KnowledgeSkillSourceError:
+        return None
+    if (
+        not layer_id
+        or not isinstance(source_root, str)
+        or not isinstance(ref, str)
+        or not ref
+        or repository is None
+        or signers is None
+    ):
+        return None
+    repository_root = _nominal(source_root)
+    if _origin(repository_root) != repository:
+        return None
+
+    if cache_root is not None:
+        base = _nominal(cache_root)
+    else:
+        from cc.core import config
+
+        configured = config.resolve_key("skills.cache_dir")
+        base = _nominal(
+            configured or Path.home() / ".claude" / "cache" / "skills"
+        ) / "signed-knowledge-v1"
+    try:
+        metadata = base.lstat()
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(metadata.st_mode) != 0o700
+        ):
+            return None
+        index = _load_snapshot_index(base)
+    except (OSError, KnowledgeSkillSourceError):
+        return None
+
+    skills_verified = verify_git_tree_release(
+        repository_root, KNOWLEDGE_SKILLS_SUBPATH, signers, ref=ref
+    )
+    if skills_verified is None:
+        return None
+    skills_snapshot = read_git_tree_snapshot(repository_root, skills_verified.tree)
+    if skills_snapshot is None:
+        return None
+    actual_login = entitlement.current_login()
+    if not actual_login:
+        return None
+    expected_state_path = str(entitlement.entitlement_state_path().expanduser())
+    content_binding = _snapshot_binding(
+        repository=repository,
+        layer=layer_id,
+        ref=skills_verified.ref,
+        tree=skills_verified.tree,
+        signer=skills_verified.signer,
+        snapshot=skills_snapshot,
+    )
+    receipts: list[dict[str, Any]] = []
+    for entry in index["entries"].values():
+        revision = entry.get("revision")
+        expected_binding = (
+            _scope_digest(
+                content_binding,
+                layer_id,
+                repository,
+                actual_login,
+                revision,
+            )
+            if isinstance(revision, int) and not isinstance(revision, bool)
+            else None
+        )
+        expected_target = (
+            _snapshot_relative_target(
+                expected_binding,
+                layer=layer_id,
+                repository=repository,
+                login=actual_login,
+                revision=revision,
+            ).as_posix()
+            if expected_binding is not None
+            else None
+        )
+        if (
+            entry.get("protected") is not True
+            or entry.get("status") != "active"
+            or entry.get("layer") != layer_id
+            or entry.get("repository") != repository
+            or entry.get("login") != actual_login
+            or entry.get("binding") != expected_binding
+            or entry.get("target") != expected_target
+            or entry.get("state_path") != expected_state_path
+            or entry.get("ref") != skills_verified.ref
+            or entry.get("tree") != skills_verified.tree
+            or entry.get("signer") != skills_verified.signer
+            or not _snapshot_matches(base / entry["target"], skills_snapshot)
+        ):
+            continue
+        _eligible, decisions = entitlement.filter_eligible_layers(
+            [layer],
+            state_path=entry["state_path"],
+            login=actual_login,
+        )
+        decision = decisions[0]
+        if not decision.eligible or decision.revision != entry.get("revision"):
+            continue
+        receipts.append(entry)
+    if len(receipts) != 1:
+        return None
+    receipt = receipts[0]
+
+    plugin_verified = verify_git_tree_release(
+        repository_root, "plugins/codex-copilot", signers, ref=ref
+    )
+    if plugin_verified is None or any(
+        getattr(plugin_verified.release, field)
+        != getattr(skills_verified.release, field)
+        for field in (
+            "ref",
+            "tag",
+            "commit",
+            "tree",
+            "signer",
+            "repository_root",
+        )
+    ):
+        return None
+    plugin_snapshot = read_git_tree_snapshot(repository_root, plugin_verified.tree)
+    if plugin_snapshot is None:
+        return None
+    return ProtectedKnowledgeLockProjection(
+        layer=layer_id,
+        repository=repository,
+        ref=skills_verified.ref,
+        tree=skills_verified.tree,
+        signer=skills_verified.signer,
+        binding=str(receipt["binding"]),
+        item_tree=plugin_verified.tree,
+        release_tree=plugin_verified.release.tree,
+        content_sha256=stable_directory_content_sha(
+            (item.path, item.content) for item in plugin_snapshot.files
+        ),
+    )
 
 
 def _effective_knowledge_layers(

--- a/tools/cc/src/cc/core/ecosystem/materialize.py
+++ b/tools/cc/src/cc/core/ecosystem/materialize.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import hashlib
 import shutil
+import stat
 import subprocess
 from pathlib import Path
 from typing import Any, Iterable, Optional, TypedDict
@@ -408,6 +409,18 @@ def _find_source_child(dim_dir: Path, item: str) -> Optional[Path]:
     return None
 
 
+def content_item_path(
+    content_root: Path | str, *, dimension: str, item: str
+) -> Optional[Path]:
+    """Resolve an item name to the file or directory materialize consumes."""
+    if any(
+        not value or Path(value).is_absolute() or Path(value).name != value
+        for value in (dimension, item)
+    ):
+        return None
+    return _find_source_child(Path(content_root).expanduser() / dimension, item)
+
+
 def stable_directory_content_sha(files: Iterable[tuple[str, bytes]]) -> str:
     """Return the canonical lock identity for an immutable directory tree.
 
@@ -441,6 +454,67 @@ def _content_sha(path: Path) -> str:
             )
         )
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def materialized_item_content_sha(
+    *,
+    product: str,
+    dimension: str,
+    item: str,
+    materialize_roots: dict[str, Path | str],
+    target_allowlist: Optional[dict[str, dict[str, str]]] = None,
+) -> Optional[str]:
+    """Read one managed destination with the materializer's lock algorithm.
+
+    This is the read-only counterpart to ``materialize()``'s private target
+    and content helpers.  It resolves file extensions exactly the same way as
+    the writer, refuses paths outside the product allow-list, and treats any
+    symlink or non-file/non-directory node in the managed item as a mismatch.
+    A caller can therefore compare the returned digest directly with the
+    item's lock pin without trusting source-checkout bytes.
+    """
+    allowlist = target_allowlist or PRODUCT_TARGET_ALLOWLIST
+    root_value = materialize_roots.get(product)
+    relative_value = allowlist.get(product, {}).get(dimension)
+    if (
+        root_value is None
+        or not relative_value
+        or not item
+        or Path(item).is_absolute()
+        or Path(item).name != item
+    ):
+        return None
+    root = Path(root_value).expanduser()
+    relative = Path(relative_value)
+    if relative.is_absolute() or ".." in relative.parts:
+        return None
+    dimension_root = root / relative
+    target = _find_source_child(dimension_root, item)
+    if target is None:
+        return None
+    try:
+        target_relative = target.relative_to(root)
+        candidates = [root]
+        current = root
+        for part in target_relative.parts:
+            current = current / part
+            candidates.append(current)
+        for candidate in candidates:
+            metadata = candidate.lstat()
+            if candidate.is_symlink() or not (
+                stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode)
+            ):
+                return None
+        if target.is_dir():
+            for child in target.rglob("*"):
+                metadata = child.lstat()
+                if child.is_symlink() or not (
+                    stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode)
+                ):
+                    return None
+        return _content_sha(target)
+    except (OSError, ValueError):
+        return None
 
 
 def _content_matches(source: Path, dest: Path) -> bool:

--- a/tools/cc/src/cc/core/ecosystem/policy.py
+++ b/tools/cc/src/cc/core/ecosystem/policy.py
@@ -459,6 +459,163 @@ def verify_git_item(
     return True, fingerprint
 
 
+def verify_git_tree_release(
+    source_root: Path | str,
+    relative_path: str,
+    allowed_signers: Sequence[str],
+    *,
+    ref: str | None = None,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    _trusted_keys: dict[str, str] | None = None,
+) -> GitItemProvenance | None:
+    """Verify an immutable signed tag and return one covered tree object.
+
+    This object-only verifier deliberately ignores mutable working-item bytes.
+    It is used when an independently integrity-checked private receipt is the
+    live authority.  The repository root and source prefix must still be real,
+    non-symlinked Git paths, and the returned tree is addressed through the
+    captured annotated-tag object rather than resolving the ref twice.
+    """
+    source = Path(os.path.abspath(Path(source_root).expanduser()))
+    relative = Path(relative_path)
+    allowed = {_normalize_fingerprint(value) for value in allowed_signers if value}
+    trusted_keys = (
+        FOUNDATION_SSH_SIGNING_KEYS if _trusted_keys is None else _trusted_keys
+    )
+    trusted = {
+        _normalize_fingerprint(fingerprint): public_key
+        for fingerprint, public_key in trusted_keys.items()
+        if _normalize_fingerprint(fingerprint) in allowed
+    }
+    if (
+        not ref
+        or relative.is_absolute()
+        or ".." in relative.parts
+        or not allowed
+        or not trusted
+    ):
+        return None
+    root = _containing_git_root(source)
+    if root is None:
+        return None
+    try:
+        source_relative = source.relative_to(root)
+        candidate = root
+        if stat.S_ISLNK(candidate.lstat().st_mode):
+            return None
+        for part in source_relative.parts:
+            candidate = candidate / part
+            metadata = candidate.lstat()
+            if stat.S_ISLNK(metadata.st_mode):
+                return None
+    except (OSError, ValueError):
+        return None
+    repo_relative = (source_relative / relative).as_posix()
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="cc-allowed-signers-") as temp_root:
+            trust_file = Path(temp_root) / "allowed_signers"
+            trust_file.write_text(
+                "".join(
+                    f'enac-foundation namespaces="git" {public_key}\n'
+                    for public_key in trusted.values()
+                ),
+                encoding="utf-8",
+            )
+            os.chmod(trust_file, 0o600)
+            tag_oid = _resolve_tag_object(root, ref, run=run)
+            if tag_oid is None:
+                return None
+            tag = run(
+                [
+                    "git",
+                    "-c",
+                    "gpg.format=ssh",
+                    "-c",
+                    f"gpg.ssh.allowedSignersFile={trust_file}",
+                    "-C",
+                    str(root),
+                    "verify-tag",
+                    tag_oid,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=8.0,
+                check=False,
+            )
+            if tag.returncode != 0:
+                return None
+            signer = _ssh_signer_fingerprint(tag.stdout, tag.stderr)
+            if signer is None or _normalize_fingerprint(signer) not in allowed:
+                return None
+            commit = run(
+                ["git", "-C", str(root), "rev-parse", f"{tag_oid}^{{commit}}"],
+                capture_output=True,
+                text=True,
+                timeout=8.0,
+                check=False,
+            )
+            if commit.returncode != 0 or not commit.stdout.strip():
+                return None
+            pinned_commit = commit.stdout.strip()
+            item_tree = run(
+                [
+                    "git",
+                    "-C",
+                    str(root),
+                    "rev-parse",
+                    f"{pinned_commit}:{repo_relative}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=8.0,
+                check=False,
+            )
+            tree_oid = item_tree.stdout.strip()
+            if item_tree.returncode != 0 or not re.fullmatch(
+                r"[0-9a-f]{40,64}", tree_oid
+            ):
+                return None
+            kind = run(
+                ["git", "-C", str(root), "cat-file", "-t", tree_oid],
+                capture_output=True,
+                text=True,
+                timeout=8.0,
+                check=False,
+            )
+            if kind.returncode != 0 or kind.stdout.strip() != "tree":
+                return None
+            root_tree_result = run(
+                ["git", "-C", str(root), "rev-parse", f"{pinned_commit}^{{tree}}"],
+                capture_output=True,
+                text=True,
+                timeout=8.0,
+                check=False,
+            )
+            root_tree = root_tree_result.stdout.strip()
+            if root_tree_result.returncode != 0 or not re.fullmatch(
+                r"[0-9a-f]{40,64}", root_tree
+            ):
+                return None
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return GitItemProvenance(
+        ref=ref,
+        tree=tree_oid,
+        signer=signer,
+        repository_root=str(root),
+        relative_path=repo_relative,
+        release=VerifiedSignedRelease(
+            ref=ref,
+            tag=tag_oid,
+            commit=pinned_commit,
+            tree=root_tree,
+            signer=signer,
+            repository_root=str(root),
+        ),
+    )
+
+
 def verify_git_item_provenance(
     source_root: Path | str,
     relative_path: str,

--- a/tools/cc/src/cc/core/ecosystem/resolver.py
+++ b/tools/cc/src/cc/core/ecosystem/resolver.py
@@ -72,10 +72,9 @@ def _make_item(
         "winning_layer": winning_layer,
         "winning_sha": winning_sha,
         "shadowed": shadowed,
-        # Fail-closed (this slice): signature-verify and materialize have
-        # not landed yet. NEVER fabricate "signed"/"matches" here — these
-        # two fields become real once the policy/materialize modules exist
-        # (see cc/commands/resolve.py's module docstring).
+        # The fold stays pure and fail-closed.  The read-only command layer
+        # enriches these defaults only after re-proving signed source and
+        # freshly hashing the materialized destination.
         "signer_of_introducing_commit": None,
         "live_hash_matches": False,
     }

--- a/tools/cc/tests/test_ecosystem_materialize.py
+++ b/tools/cc/tests/test_ecosystem_materialize.py
@@ -22,10 +22,12 @@ from pathlib import Path
 import pytest
 from cc.core.ecosystem.discovery import discover_contributions
 from cc.core.ecosystem.materialize import (
+    content_item_path,
     guard_personal,
     guard_personal_reason,
     materialize,
     materialize_ecosystem_config,
+    materialized_item_content_sha,
 )
 from cc.core.ecosystem.policy import evaluate as fail_closed_policy
 from cc.core.ecosystem.policy import permissive_policy
@@ -86,6 +88,57 @@ def _fingerprint_tree(path: Path) -> str:
             digest.update(child.relative_to(path).as_posix().encode("utf-8"))
             digest.update(child.read_bytes())
     return digest.hexdigest()
+
+
+def test_materialized_item_content_sha_matches_file_lock_identity(tmp_path):
+    root = tmp_path / "claude"
+    item = root / "agents" / "sec.md"
+    item.parent.mkdir(parents=True)
+    item.write_bytes(b"security agent\n")
+
+    assert materialized_item_content_sha(
+        product="claude",
+        dimension="agents",
+        item="sec",
+        materialize_roots={"claude": root},
+    ) == hashlib.sha256(item.read_bytes()).hexdigest()
+
+
+def test_materialized_item_content_sha_fails_closed_on_symlink(tmp_path):
+    root = tmp_path / "claude"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "sec.md").write_text("security agent\n", encoding="utf-8")
+    root.mkdir()
+    (root / "agents").symlink_to(outside, target_is_directory=True)
+
+    assert (
+        materialized_item_content_sha(
+            product="claude",
+            dimension="agents",
+            item="sec",
+            materialize_roots={"claude": root},
+        )
+        is None
+    )
+
+
+def test_read_only_item_helpers_reject_path_traversal(tmp_path):
+    root = tmp_path / "materialized"
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside\n", encoding="utf-8")
+    (root / "agents").mkdir(parents=True)
+
+    assert content_item_path(root, dimension="agents", item="../outside") is None
+    assert (
+        materialized_item_content_sha(
+            product="claude",
+            dimension="agents",
+            item="../outside",
+            materialize_roots={"claude": root},
+        )
+        is None
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tools/cc/tests/test_ecosystem_mirror.py
+++ b/tools/cc/tests/test_ecosystem_mirror.py
@@ -15,7 +15,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-
 from cc.core.ecosystem import mirror
 
 
@@ -310,13 +309,13 @@ def test_clone_or_update_mirror_resolves_caret_semver_to_highest_compatible_tag(
     tmp_path,
 ):
     source = _make_content_repo(tmp_path, {"version.txt": "0.3.0"})
-    subprocess.run(["git", "tag", "v0.3.0"], cwd=source, check=True)
+    subprocess.run(["git", "tag", "--no-sign", "v0.3.0"], cwd=source, check=True)
     (source / "version.txt").write_text("0.3.1", encoding="utf-8")
     subprocess.run(["git", "commit", "-aqm", "v0.3.1"], cwd=source, check=True)
-    subprocess.run(["git", "tag", "v0.3.1"], cwd=source, check=True)
+    subprocess.run(["git", "tag", "--no-sign", "v0.3.1"], cwd=source, check=True)
     (source / "version.txt").write_text("0.4.0", encoding="utf-8")
     subprocess.run(["git", "commit", "-aqm", "v0.4.0"], cwd=source, check=True)
-    subprocess.run(["git", "tag", "v0.4.0"], cwd=source, check=True)
+    subprocess.run(["git", "tag", "--no-sign", "v0.4.0"], cwd=source, check=True)
 
     result = mirror.clone_or_update_mirror(
         "foundation",

--- a/tools/cc/tests/test_ecosystem_policy.py
+++ b/tools/cc/tests/test_ecosystem_policy.py
@@ -386,7 +386,7 @@ def test_git_item_real_repro_still_blocks_genuinely_unsigned_tag(tmp_path):
         ["git", "commit", "-q", "--no-gpg-sign", "-m", "add skill"], cwd=repo, check=True
     )
     # Lightweight (unsigned) tag -- `git verify-tag` must reject it outright.
-    subprocess.run(["git", "tag", "v1.0.0"], cwd=repo, check=True)
+    subprocess.run(["git", "tag", "--no-sign", "v1.0.0"], cwd=repo, check=True)
 
     assert verify_git_item(
         repo,

--- a/tools/cc/tests/test_knowledge_skill_source.py
+++ b/tools/cc/tests/test_knowledge_skill_source.py
@@ -16,6 +16,7 @@ from cc.core.ecosystem import entitlement
 from cc.core.ecosystem.knowledge_skill_source import (
     KNOWLEDGE_SKILLS_SUBPATH,
     KnowledgeSkillSourceError,
+    inspect_protected_knowledge_lock_projection,
     prune_all_knowledge_snapshots,
     resolve_knowledge_skill_sources,
     resolve_protected_knowledge_lock_projections,
@@ -236,6 +237,89 @@ def test_protected_receipt_projects_exact_signed_plugin_lock_identity(
     assert projection.release_tree == source.release.tree
     assert projection.content_sha256 == stable_directory_content_sha(
         (item.path, item.content) for item in snapshot.files
+    )
+
+
+def test_read_only_projection_inspector_reproves_active_receipt(
+    protected_signed_source,
+):
+    _source, projection = _protected_projection(protected_signed_source)
+    _repo, layer, _state_path, cache_root = protected_signed_source
+    index_path = cache_root / "index.json"
+    index_before = index_path.read_bytes()
+
+    inspected = inspect_protected_knowledge_lock_projection(
+        layer, cache_root=cache_root
+    )
+
+    assert inspected == projection
+    assert index_path.read_bytes() == index_before
+
+
+def test_read_only_projection_inspector_uses_receipt_not_checkout_bytes(
+    protected_signed_source,
+):
+    _source, projection = _protected_projection(protected_signed_source)
+    repo, layer, _state_path, cache_root = protected_signed_source
+    (repo / KNOWLEDGE_SKILLS_SUBPATH / "accounting" / "SKILL.md").write_text(
+        "mutable checkout replacement\n", encoding="utf-8"
+    )
+    (repo / "plugins" / "codex-copilot" / "SKILL.md").write_text(
+        "mutable plugin replacement\n", encoding="utf-8"
+    )
+
+    assert (
+        inspect_protected_knowledge_lock_projection(layer, cache_root=cache_root)
+        == projection
+    )
+
+
+def test_read_only_projection_inspector_fails_closed_on_receipt_tamper(
+    protected_signed_source,
+):
+    _source, projection = _protected_projection(protected_signed_source)
+    _repo, layer, _state_path, cache_root = protected_signed_source
+    _tamper_protected_receipt(cache_root, projection.binding)
+
+    assert (
+        inspect_protected_knowledge_lock_projection(layer, cache_root=cache_root)
+        is None
+    )
+
+
+def test_read_only_projection_inspector_fails_closed_on_newer_revocation(
+    protected_signed_source,
+):
+    _source, _projection = _protected_projection(protected_signed_source)
+    _repo, layer, state_path, cache_root = protected_signed_source
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["next_sequence"] = 3
+    state["layers"]["knowledge-test"]["state"] = "revoked"
+    state["layers"]["knowledge-test"]["revision"] = 2
+    atomic_json_write(state_path, state)
+
+    assert (
+        inspect_protected_knowledge_lock_projection(layer, cache_root=cache_root)
+        is None
+    )
+
+
+def test_read_only_projection_inspector_rejects_alternate_entitlement_ledger(
+    protected_signed_source,
+):
+    _source, projection = _protected_projection(protected_signed_source)
+    _repo, layer, state_path, cache_root = protected_signed_source
+    alternate = state_path.with_name("forged-entitlements.json")
+    alternate.write_bytes(state_path.read_bytes())
+    alternate.chmod(0o600)
+    index_path = cache_root / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["entries"][projection.binding]["state_path"] = str(alternate)
+    atomic_json_write(index_path, index)
+
+    assert (
+        inspect_protected_knowledge_lock_projection(layer, cache_root=cache_root)
+        is None
     )
 
 
@@ -550,7 +634,7 @@ def test_signed_release_blob_read_ignores_checkout_and_tag_switch(signed_source)
     (repo / ".claude/extensions/do.extension.md").write_text(
         "mutable checkout replacement\n", encoding="utf-8"
     )
-    _run(repo, "tag", "-f", "v1.0.0", "HEAD")
+    _run(repo, "tag", "--no-sign", "-f", "v1.0.0", "HEAD")
 
     assert source.release.read_blob(".claude/extensions/do.extension.md") == expected
 
@@ -634,7 +718,7 @@ def test_unsigned_tag_and_symlinked_item_fail_closed(
     signed_source, monkeypatch: pytest.MonkeyPatch
 ):
     repo, fingerprint = signed_source
-    _run(repo, "tag", "unsigned")
+    _run(repo, "tag", "--no-sign", "unsigned")
     monkeypatch.setattr(
         "cc.core.config.resolve_key",
         lambda key: {

--- a/tools/cc/tests/test_onboard_contract.py
+++ b/tools/cc/tests/test_onboard_contract.py
@@ -3100,7 +3100,7 @@ def _lightweight_tag(path: Path, tag: str, message: str = "unused") -> None:
     `FETCH_HEAD` never needed peeling for this case, so it never reproduced
     the live annotated-tag bug on its own -- kept as a regression guard that
     the fix's `^{commit}` peel is also a no-op passthrough here."""
-    subprocess.run(["git", "-C", str(path), "tag", tag], check=True)
+    subprocess.run(["git", "-C", str(path), "tag", "--no-sign", tag], check=True)
 
 
 def _annotated_tag(path: Path, tag: str, message: str = "release") -> None:

--- a/tools/cc/tests/test_resolve_contract.py
+++ b/tools/cc/tests/test_resolve_contract.py
@@ -17,6 +17,7 @@ import json
 from pathlib import Path
 
 import pytest
+from cc.commands.resolve import build_resolve_report
 from cc.core.ecosystem.discovery import discover_contributions
 from cc.main import app
 from jsonschema import Draft202012Validator
@@ -144,15 +145,101 @@ def test_resolve_explain_json_validates_against_contract_schema(monkeypatch, tmp
 
 
 def test_resolve_explain_json_fail_closed_security_fields(monkeypatch, tmp_path):
-    """Every item must emit signer_of_introducing_commit: null and
-    live_hash_matches: false until signature-verify + materialize land --
-    never a fabricated 'signed'/'matches' verdict."""
+    """Missing signed/materialized evidence remains null/false."""
     payload, _ = _invoke_resolve_json(monkeypatch, tmp_path)
 
     assert payload["items"]
     for entry in payload["items"]:
         assert entry["signer_of_introducing_commit"] is None
         assert entry["live_hash_matches"] is False
+
+
+def test_resolve_enriches_verified_signer_and_live_destination_hash(
+    monkeypatch, tmp_path
+):
+    source_root = _write_fixture_layer(tmp_path)
+    materialize_root = tmp_path / "materialized-claude"
+    destination = materialize_root / "agents" / "sec.md"
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes((source_root / "agents" / "sec.md").read_bytes())
+    layer = {
+        "id": "foundation",
+        "role": "foundation",
+        "rank": 40,
+        "product": "claude",
+        "source": {
+            "repo": "https://example.invalid/foundation.git",
+            "ref": "v1.0.0",
+            "path": str(source_root),
+        },
+        "auth": "anon",
+        "activation": "always",
+        "policy": {"allowed_signers": ["SHA256:test-signer"]},
+    }
+    contributions = discover_contributions([layer])
+    locked_sha = contributions["foundation"]["agents"]["sec"]
+    monkeypatch.setattr(
+        "cc.commands.resolve.verify_git_item",
+        lambda *args, **kwargs: (True, "SHA256:test-signer"),
+    )
+
+    report = build_resolve_report(
+        _layers=[layer],
+        _contributions=contributions,
+        _lockfile={"foundation": {"agents": {"sec": locked_sha}}},
+        _mirror_root=tmp_path / "mirrors",
+        _materialize_roots={"claude": materialize_root},
+        _knowledge_cache_root=tmp_path / "knowledge-cache",
+    )
+
+    assert report["items"][0]["signer_of_introducing_commit"] == (
+        "SHA256:test-signer"
+    )
+    assert report["items"][0]["live_hash_matches"] is True
+
+
+def test_resolve_reports_modified_destination_without_losing_source_signer(
+    monkeypatch, tmp_path
+):
+    source_root = _write_fixture_layer(tmp_path)
+    materialize_root = tmp_path / "materialized-claude"
+    destination = materialize_root / "agents" / "sec.md"
+    destination.parent.mkdir(parents=True)
+    destination.write_text("tampered destination\n", encoding="utf-8")
+    layer = {
+        "id": "foundation",
+        "role": "foundation",
+        "rank": 40,
+        "product": "claude",
+        "source": {
+            "repo": "https://example.invalid/foundation.git",
+            "ref": "v1.0.0",
+            "path": str(source_root),
+        },
+        "auth": "anon",
+        "activation": "always",
+        "policy": {"allowed_signers": ["SHA256:test-signer"]},
+    }
+    contributions = discover_contributions([layer])
+    locked_sha = contributions["foundation"]["agents"]["sec"]
+    monkeypatch.setattr(
+        "cc.commands.resolve.verify_git_item",
+        lambda *args, **kwargs: (True, "SHA256:test-signer"),
+    )
+
+    report = build_resolve_report(
+        _layers=[layer],
+        _contributions=contributions,
+        _lockfile={"foundation": {"agents": {"sec": locked_sha}}},
+        _mirror_root=tmp_path / "mirrors",
+        _materialize_roots={"claude": materialize_root},
+        _knowledge_cache_root=tmp_path / "knowledge-cache",
+    )
+
+    assert report["items"][0]["signer_of_introducing_commit"] == (
+        "SHA256:test-signer"
+    )
+    assert report["items"][0]["live_hash_matches"] is False
 
 
 def test_resolve_no_manifest_configured_returns_schema_valid_empty_report(monkeypatch):


### PR DESCRIPTION
## Outcome

`cc resolve --explain` now reports freshly re-proved release signer and live-content evidence instead of permanent placeholder values.

## Trust path

- captures one immutable annotated-tag object before signature, commit, and tree resolution
- hashes managed destinations with the materializer's canonical lock algorithm
- re-proves protected Knowledge through one active private receipt, the canonical entitlement ledger, and the same signed release
- fails closed for symlinks, traversal, alternate ledgers, revocation, receipt tamper, missing objects, unsigned tags, unknown signers, and byte mismatches
- keeps personal-write memory explicitly unverified because it is never materialized or lock-pinned

## Evidence

- candidate commit: `469138867cd22422ca7785475c7d858b3f195392`
- candidate tree: `ce7463bf944102079b385306cf8028bd1576cba5`
- complete deterministic `tools/cc/tests` suite excluding explicit live-machine tests: 100% passed
- affected resolve/resolver/materialize/Knowledge/policy/mirror/onboarding suites: passed
- Ruff: passed
- `git diff --check`: passed
- real-machine source proof: 56 resolved, 50 verified signers, 53 live matches; only the three intentionally unpinned memory items remain false

No Control Tower app source is in scope or changed.
