### PR TITLE
chore: publish framework v5.14.5

### DIFF
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,5 +1,5 @@
 {
-  "framework": "5.14.4",
+  "framework": "5.14.5",
   "lastUpdated": "2026-08-14T00:00:00.000Z",
   "components": {
     "cc": {

--- a/copilot.lock.json
+++ b/copilot.lock.json
@@ -130,8 +130,8 @@
         }
       ],
       "ownership_mode": "full",
-      "release_tag": "v5.14.4",
-      "version": "5.14.4"
+      "release_tag": "v5.14.5",
+      "version": "5.14.5"
     },
     {
       "component": "codex",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilot/framework",
-  "version": "5.14.4",
+  "version": "5.14.5",
   "description": "Claude Copilot - AI-enabled development framework",
   "private": true,
   "scripts": {

--- a/tools/cc/tests/conformance/fixtures/reference-install/manifest.json
+++ b/tools/cc/tests/conformance/fixtures/reference-install/manifest.json
@@ -2,7 +2,7 @@
   "_comment": "Golden-tree description for Layer 5's round-trip (and, per HARNESS-DESIGN.md section 5.2, reusable by Layer 3). Every field here was verified directly against VERSION.json and, where noted, a read-only inspection of the reference install on this machine -- never assumed from RUBRIC.md, which has two confirmed errors recorded below. See TEST-MATRIX.md section 5 'Ground truth constants'.",
   "generated_at": "2026-08-10",
   "verified_against": {
-    "version_json": "VERSION.json (framework 5.14.4, agents 5.6.0, commands 5.3.2)",
+    "version_json": "VERSION.json (framework 5.14.5, agents 5.6.0, commands 5.3.2)",
     "reference_install": "/Volumes/Dev/Sites/TSM/hermes (read-only inspection; no single repo is a complete reference -- hermes itself fails D3/D4/D7/D11/D12 per TEST-MATRIX.md)",
     "codex_plugin_source": "/Volumes/Dev/Sites/COPILOT/codex-copilot/plugins/codex-copilot (read-only file count)"
   },


### PR DESCRIPTION
## Why

v5.14.4 was published with a GitHub-valid but runtime-untrusted repository-local signing key. The fail-closed installer correctly refused it. This advances the immutable release identity without rewriting the published tag.

## Verification

- dedicated ENAC foundation key signs the candidate commit
- version consistency script passes
- version detection, reference round-trip, and conformance command suites pass
- hosted checks must pass on the exact head before admin merge