### PR TITLE
perf(cc): batch authenticated extension resolution

### DIFF
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,9 +1,9 @@
 {
-  "framework": "5.14.6",
+  "framework": "5.14.7",
   "lastUpdated": "2026-08-14T00:00:00.000Z",
   "components": {
     "cc": {
-      "version": "2.12.9",
+      "version": "2.12.10",
       "path": "tools/cc",
       "installScript": "tools/cc/install.sh",
       "provides": ["cc memory", "cc memory check", "cc skill", "cc config", "cc env", "cc docs", "cc usage", "cc eval", "cc reconcile", "cc store", "cc support"]

--- a/copilot.lock.json
+++ b/copilot.lock.json
@@ -130,8 +130,8 @@
         }
       ],
       "ownership_mode": "full",
-      "release_tag": "v5.14.6",
-      "version": "5.14.6"
+      "release_tag": "v5.14.7",
+      "version": "5.14.7"
     },
     {
       "component": "codex",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilot/framework",
-  "version": "5.14.6",
+  "version": "5.14.7",
   "description": "Claude Copilot - AI-enabled development framework",
   "private": true,
   "scripts": {

--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "2.12.9"
+version = "2.12.10"
 description = "Unified Claude Copilot CLI for memory, skills, config, and live docs"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI for memory, skills, config, and live docs."""
 
-__version__ = "2.12.9"
+__version__ = "2.12.10"

--- a/tools/cc/src/cc/commands/conformance.py
+++ b/tools/cc/src/cc/commands/conformance.py
@@ -118,6 +118,10 @@ from cc.core.ecosystem.reconciliation import (
     build_verify_report,
 )
 from cc.core.ecosystem.resolver import resolve_layers
+from cc.core.extensions_resolver import (
+    ExtensionSkillBindings,
+    prepare_extension_source_bindings,
+)
 
 conformance_app = typer.Typer(
     help=(
@@ -285,15 +289,34 @@ def _run_tier_layer_machine() -> tuple[CheckResult, ...]:
     ladder = resolve_knowledge_repos()
     if not ladder:
         return tuple(results)
+    source_bindings = prepare_extension_source_bindings(ladder)
+    skill_bindings = ExtensionSkillBindings(tuple(ladder), source_bindings)
 
     for agent in sorted(_declared_agent_names(ladder)):
         results.append(
-            tier.check_h1_nearest_declared_wins(agent, knowledge_repos=ladder)
+            tier.check_h1_nearest_declared_wins(
+                agent,
+                knowledge_repos=ladder,
+                source_bindings=source_bindings,
+                skill_bindings=skill_bindings,
+            )
         )
         results.append(
-            tier.check_h2_absence_is_not_shadow(agent, knowledge_repos=ladder)
+            tier.check_h2_absence_is_not_shadow(
+                agent,
+                knowledge_repos=ladder,
+                source_bindings=source_bindings,
+                skill_bindings=skill_bindings,
+            )
         )
-        results.append(tier.check_h3_shadow_substance(agent, knowledge_repos=ladder))
+        results.append(
+            tier.check_h3_shadow_substance(
+                agent,
+                knowledge_repos=ladder,
+                source_bindings=source_bindings,
+                skill_bindings=skill_bindings,
+            )
+        )
 
     layers = _load_validated_layers()
     expected_ladder = (

--- a/tools/cc/src/cc/commands/extensions.py
+++ b/tools/cc/src/cc/commands/extensions.py
@@ -73,7 +73,13 @@ def extensions_resolve(
     extensions[] entries by agent id, verifies requiredSkills, and applies
     fallbackBehavior. Never raises on a missing/malformed manifest.
     """
-    from cc.core.extensions_resolver import ACTION_FALLBACK_FAIL, resolve_extension
+    from cc.core.config import resolve_knowledge_repos
+    from cc.core.extensions_resolver import (
+        ACTION_FALLBACK_FAIL,
+        ExtensionSkillBindings,
+        prepare_extension_source_bindings,
+        resolve_extension,
+    )
 
     if not agent and not all_agents:
         err_console.print("[red]Error:[/red] pass --agent <id> or --all")
@@ -84,7 +90,18 @@ def extensions_resolve(
     if all_agents and not agent_ids:
         err_console.print("[yellow]No agents found under .claude/agents/ -- nothing to resolve.[/yellow]")
 
-    results = [resolve_extension(a) for a in agent_ids]
+    knowledge_repos = resolve_knowledge_repos()
+    source_bindings = prepare_extension_source_bindings(knowledge_repos)
+    skill_bindings = ExtensionSkillBindings(tuple(knowledge_repos), source_bindings)
+    results = [
+        resolve_extension(
+            a,
+            knowledge_repos=knowledge_repos,
+            source_bindings=source_bindings,
+            skill_bindings=skill_bindings,
+        )
+        for a in agent_ids
+    ]
 
     if output_json:
         payload = [r.to_dict() for r in results]

--- a/tools/cc/src/cc/core/conformance/tier.py
+++ b/tools/cc/src/cc/core/conformance/tier.py
@@ -82,7 +82,12 @@ from cc.core.conformance.types import (
     Severity,
     Verdict,
 )
-from cc.core.extensions_resolver import ACTION_APPLY, resolve_extension
+from cc.core.extensions_resolver import (
+    ACTION_APPLY,
+    ExtensionSkillBindings,
+    ExtensionSourceBindings,
+    resolve_extension,
+)
 
 # `resolve_extension`'s own signature types `missing_skills_checker` as
 # `Callable[[list[str]], list[str]] | None`; extensions_resolver.py does not
@@ -414,11 +419,19 @@ def check_h1_nearest_declared_wins(
     *,
     knowledge_repos: Sequence[str],
     missing_skills_checker: MissingSkillsChecker | None = None,
+    source_bindings: ExtensionSourceBindings | None = None,
+    skill_bindings: ExtensionSkillBindings | None = None,
 ) -> CheckResult:
     repos = list(knowledge_repos)
-    resolution = resolve_extension(
-        agent, knowledge_repos=repos, missing_skills_checker=missing_skills_checker
-    )
+    resolver_kwargs: dict[str, Any] = {
+        "knowledge_repos": repos,
+        "missing_skills_checker": missing_skills_checker,
+    }
+    if source_bindings is not None:
+        resolver_kwargs["source_bindings"] = source_bindings
+    if skill_bindings is not None:
+        resolver_kwargs["skill_bindings"] = skill_bindings
+    resolution = resolve_extension(agent, **resolver_kwargs)
     declaring = _declaring_repos_in_order(agent, repos)
 
     if not declaring:
@@ -466,6 +479,8 @@ def check_h2_absence_is_not_shadow(
     *,
     knowledge_repos: Sequence[str],
     missing_skills_checker: MissingSkillsChecker | None = None,
+    source_bindings: ExtensionSourceBindings | None = None,
+    skill_bindings: ExtensionSkillBindings | None = None,
 ) -> CheckResult:
     repos = list(knowledge_repos)
     declaring = _declaring_repos_in_order(agent, repos)
@@ -492,9 +507,15 @@ def check_h2_absence_is_not_shadow(
             ),
         )
 
-    resolution = resolve_extension(
-        agent, knowledge_repos=repos, missing_skills_checker=missing_skills_checker
-    )
+    resolver_kwargs: dict[str, Any] = {
+        "knowledge_repos": repos,
+        "missing_skills_checker": missing_skills_checker,
+    }
+    if source_bindings is not None:
+        resolver_kwargs["source_bindings"] = source_bindings
+    if skill_bindings is not None:
+        resolver_kwargs["skill_bindings"] = skill_bindings
+    resolution = resolve_extension(agent, **resolver_kwargs)
     ok = (
         resolution.action == ACTION_APPLY
         and resolution.source_repo == nearest_declaring
@@ -540,12 +561,20 @@ def check_h3_shadow_substance(
     *,
     knowledge_repos: Sequence[str],
     missing_skills_checker: MissingSkillsChecker | None = None,
+    source_bindings: ExtensionSourceBindings | None = None,
+    skill_bindings: ExtensionSkillBindings | None = None,
     minimum_size_ratio: float = 0.5,
 ) -> CheckResult:
     repos = list(knowledge_repos)
-    resolution = resolve_extension(
-        agent, knowledge_repos=repos, missing_skills_checker=missing_skills_checker
-    )
+    resolver_kwargs: dict[str, Any] = {
+        "knowledge_repos": repos,
+        "missing_skills_checker": missing_skills_checker,
+    }
+    if source_bindings is not None:
+        resolver_kwargs["source_bindings"] = source_bindings
+    if skill_bindings is not None:
+        resolver_kwargs["skill_bindings"] = skill_bindings
+    resolution = resolve_extension(agent, **resolver_kwargs)
     if not resolution.matched or not resolution.file:
         return H3_SHADOW_SUBSTANCE.result(
             subject=agent,
@@ -569,11 +598,15 @@ def check_h3_shadow_substance(
     winner_size = winner_path.stat().st_size
 
     shadow_repo = shadowed[0]
-    shadow_resolution = resolve_extension(
-        agent,
-        knowledge_repos=[shadow_repo],
-        missing_skills_checker=missing_skills_checker,
-    )
+    shadow_kwargs: dict[str, Any] = {
+        "knowledge_repos": [shadow_repo],
+        "missing_skills_checker": missing_skills_checker,
+    }
+    if source_bindings is not None:
+        shadow_kwargs["source_bindings"] = source_bindings
+    if skill_bindings is not None:
+        shadow_kwargs["skill_bindings"] = skill_bindings
+    shadow_resolution = resolve_extension(agent, **shadow_kwargs)
     shadow_size = (
         Path(shadow_resolution.file).stat().st_size if shadow_resolution.file else 0
     )

--- a/tools/cc/src/cc/core/ecosystem/knowledge_skill_source.py
+++ b/tools/cc/src/cc/core/ecosystem/knowledge_skill_source.py
@@ -128,6 +128,24 @@ class VerifiedKnowledgeSkillSource:
     ) -> AuthenticatedKnowledgeContribution:
         """Read exact UTF-8 contribution bytes under current entitlement."""
         current = revalidate_knowledge_skill_source(self)
+        return current.authenticated_contribution_from_verified_batch(
+            relative_path,
+            runtime=runtime,
+        )
+
+    def authenticated_contribution_from_verified_batch(
+        self, relative_path: str, *, runtime: str
+    ) -> AuthenticatedKnowledgeContribution:
+        """Read one contribution from a caller-scoped verified source batch.
+
+        The source must come directly from the current operation's
+        ``resolve_knowledge_skill_sources`` result. The signed release tree is
+        immutable, and protected reads still hold and validate the bound
+        entitlement ledger lease. This avoids recursively resolving the same
+        ladder for every contribution while preserving fresh validation at the
+        start of each new operation.
+        """
+        current = self
         contribution = Path(relative_path)
         if contribution.is_absolute() or ".." in contribution.parts:
             raise KnowledgeSkillSourceError(

--- a/tools/cc/src/cc/core/extensions_resolver.py
+++ b/tools/cc/src/cc/core/extensions_resolver.py
@@ -48,7 +48,7 @@ import json
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Mapping, Optional, Sequence
 
 _log = logging.getLogger(__name__)
 
@@ -131,6 +131,151 @@ class AuthenticatedComposition:
     content_sha256: str
 
 
+ExtensionSourceBindings = Mapping[str, tuple[bool, Any]]
+
+
+def _repository_key(repo: str | Path) -> str:
+    return str(Path(repo).expanduser().absolute())
+
+
+def prepare_extension_source_bindings(
+    knowledge_repos: Sequence[str],
+) -> dict[str, tuple[bool, Any]]:
+    """Verify the signed Knowledge ladder once for one resolution batch.
+
+    The returned mapping is intentionally caller-scoped and never cached
+    globally. A command or conformance collection therefore gets one stable,
+    entitlement-bound view while the next invocation always revalidates the
+    current authorization and signed source state.
+    """
+
+    bindings: dict[str, tuple[bool, Any]] = {}
+    try:
+        from cc.core.ecosystem.knowledge_skill_source import (
+            knowledge_repository_requires_authenticated_source,
+            resolve_knowledge_skill_sources,
+        )
+    except Exception:
+        return {_repository_key(repo): (True, None) for repo in knowledge_repos}
+
+    protected: dict[str, bool] = {}
+    for repo in knowledge_repos:
+        key = _repository_key(repo)
+        try:
+            protected[key] = knowledge_repository_requires_authenticated_source(
+                Path(key)
+            )
+        except Exception:
+            protected[key] = True
+
+    sources_by_repo: dict[str, Any] = {}
+    if any(protected.values()):
+        try:
+            for _root, source in resolve_knowledge_skill_sources():
+                if source is not None:
+                    sources_by_repo[_repository_key(source.repository_root)] = source
+        except Exception:
+            # Preserve the existing fail-closed behavior: an unavailable or
+            # invalid signed ladder grants no protected checkout authority.
+            sources_by_repo = {}
+
+    for key, authentication_required in protected.items():
+        bindings[key] = (
+            authentication_required,
+            sources_by_repo.get(key) if authentication_required else None,
+        )
+    return bindings
+
+
+@dataclass
+class ExtensionSkillBindings:
+    """Lazy skill index shared by one extension-resolution operation."""
+
+    knowledge_repos: tuple[str, ...]
+    source_bindings: ExtensionSourceBindings
+    _skills: list[Any] | None = field(default=None, init=False, repr=False)
+
+    def _catalog(self) -> list[Any]:
+        if self._skills is not None:
+            return self._skills
+
+        from cc.core.ecosystem.knowledge_skill_source import (
+            KNOWLEDGE_SKILLS_SUBPATH,
+        )
+        from cc.core.skill_store import (
+            default_skill_paths,
+            discover_skills_with_sources,
+        )
+
+        knowledge_sources: list[tuple[Path, Any]] = []
+        sources_by_root: dict[Path, Any] = {}
+        for repo in self.knowledge_repos:
+            key = _repository_key(repo)
+            authentication_required, source = self.source_bindings.get(
+                key, (True, None)
+            )
+            if source is not None:
+                skills_root = Path(source.skills_root).expanduser().absolute()
+                knowledge_sources.append((skills_root, source))
+                sources_by_root[skills_root] = source
+                continue
+            if authentication_required:
+                continue
+            skills_root = Path(key) / KNOWLEDGE_SKILLS_SUBPATH
+            if skills_root.is_dir():
+                knowledge_sources.append((skills_root, None))
+                sources_by_root[skills_root] = None
+
+        self._skills = discover_skills_with_sources(
+            default_skill_paths(knowledge_sources=knowledge_sources),
+            cache_dir=None,
+            _knowledge_sources=sources_by_root,
+        )
+        return self._skills
+
+    def evaluate(self, required: list[str]) -> tuple[list[str], tuple[Any, ...]]:
+        """Return missing skill names and authenticated receipts in one scan."""
+        if not required:
+            return [], ()
+        from cc.core.skill_store import (
+            find_skill_by_name,
+            get_skill_content_with_receipt_from_verified_batch,
+        )
+
+        try:
+            skills = self._catalog()
+        except Exception:
+            _log.debug(
+                "extensions resolver: skill availability check failed",
+                exc_info=True,
+            )
+            return list(required), ()
+
+        missing = []
+        receipts = []
+        for name in required:
+            skill = find_skill_by_name(name, skills)
+            if skill is None:
+                missing.append(name)
+                continue
+            if skill._knowledge_source is None:
+                continue
+            try:
+                result = get_skill_content_with_receipt_from_verified_batch(
+                    skill, runtime="claude"
+                )
+            except Exception:
+                _log.debug(
+                    "extensions resolver: authenticated skill receipt unavailable",
+                    exc_info=True,
+                )
+                missing.append(name)
+                continue
+            if result.receipt is not None:
+                receipts.append(result.receipt)
+        return missing, tuple(receipts)
+
+
 def _load_manifest(repo: str) -> Optional[dict]:
     """Parse `<repo>/knowledge-manifest.json`. Returns None (with a logged
     warning) for anything short of a well-formed JSON object -- absent
@@ -154,13 +299,19 @@ def _load_manifest(repo: str) -> Optional[dict]:
     return data
 
 
-def _signed_source_for_repo(repo: str) -> tuple[bool, Any]:
+def _signed_source_for_repo(
+    repo: str,
+    source_bindings: ExtensionSourceBindings | None = None,
+) -> tuple[bool, Any]:
     """Return ``(authentication_required, source)`` for one repository.
 
     The first value is deliberately independent of source availability.  A
     revoked or unverifiable manifest-declared source therefore remains an
     authenticated source and cannot fall through to mutable checkout bytes.
     """
+    key = _repository_key(repo)
+    if source_bindings is not None:
+        return source_bindings.get(key, (True, None))
     try:
         from cc.core.ecosystem.knowledge_skill_source import (
             knowledge_repository_requires_authenticated_source,
@@ -197,7 +348,7 @@ def _load_manifest_authenticated(
             return None
         return _load_manifest(repo)
     try:
-        receipt = source.authenticated_contribution(
+        receipt = source.authenticated_contribution_from_verified_batch(
             "knowledge-manifest.json", runtime="claude"
         )
         data = json.loads(receipt.content)
@@ -217,62 +368,13 @@ def _find_agent_extension(manifest: dict, agent: str) -> Optional[dict]:
     return None
 
 
-def _default_missing_skills(required: list[str]) -> list[str]:
-    """Verify `required` skill names via the exact same lookup `cc skill
-    get` uses (`core/skill_store.py`'s `default_skill_paths()` +
-    `discover_skills_with_sources()`), so a skill this resolver says is
-    available is guaranteed retrievable by the agent that reads it next.
-    Returns the subset of `required` that could NOT be found. Never
-    raises -- an unreadable skill tree is treated as "missing", not a
-    crash."""
-    if not required:
-        return []
-    try:
-        from cc.core.skill_store import (
-            default_skill_paths,
-            discover_skills_with_sources,
-            find_skill_by_name,
-        )
-
-        pairs = default_skill_paths()
-        skills = discover_skills_with_sources(pairs, cache_dir=None)
-        return [name for name in required if find_skill_by_name(name, skills) is None]
-    except Exception:
-        _log.debug("extensions resolver: skill availability check failed", exc_info=True)
-        return list(required)
-
-
-def _required_skill_receipts(required: list[str]) -> tuple[Any, ...]:
-    if not required:
-        return ()
-    try:
-        from cc.core.skill_store import (
-            default_skill_paths,
-            discover_skills_with_sources,
-            find_skill_by_name,
-            get_skill_content_with_receipt,
-        )
-
-        skills = discover_skills_with_sources(default_skill_paths(), cache_dir=None)
-        receipts = []
-        for name in required:
-            skill = find_skill_by_name(name, skills)
-            if skill is None:
-                continue
-            result = get_skill_content_with_receipt(skill, runtime="claude")
-            if result.receipt is not None:
-                receipts.append(result.receipt)
-        return tuple(receipts)
-    except Exception:
-        _log.debug("extensions resolver: skill receipt lookup failed", exc_info=True)
-        return ()
-
-
 def resolve_extension(
     agent: str,
     *,
     knowledge_repos: Optional[list[str]] = None,
     missing_skills_checker: Optional[Callable[[list[str]], list[str]]] = None,
+    source_bindings: ExtensionSourceBindings | None = None,
+    skill_bindings: ExtensionSkillBindings | None = None,
 ) -> ExtensionResolution:
     """Resolve the winning extension (if any) for `agent`.
 
@@ -300,10 +402,17 @@ def resolve_extension(
 
         knowledge_repos = resolve_knowledge_repos()
 
-    checker = missing_skills_checker or _default_missing_skills
+    if source_bindings is None:
+        source_bindings = prepare_extension_source_bindings(knowledge_repos)
+    if missing_skills_checker is None and skill_bindings is None:
+        skill_bindings = ExtensionSkillBindings(
+            tuple(knowledge_repos), source_bindings
+        )
 
     for repo in knowledge_repos:
-        authentication_required, signed_source = _signed_source_for_repo(repo)
+        authentication_required, signed_source = _signed_source_for_repo(
+            repo, source_bindings
+        )
         manifest = _load_manifest_authenticated(
             repo,
             signed_source,
@@ -333,7 +442,7 @@ def resolve_extension(
         extension_receipt = None
         if signed_source is not None:
             try:
-                extension_receipt = signed_source.authenticated_contribution(
+                extension_receipt = signed_source.authenticated_contribution_from_verified_batch(
                     file_rel, runtime="claude"
                 )
             except Exception as exc:
@@ -356,12 +465,14 @@ def resolve_extension(
         if fallback not in _VALID_FALLBACKS:
             fallback = _DEFAULT_FALLBACK
 
-        missing = checker(required)
-        skill_receipts = (
-            _required_skill_receipts(required)
-            if missing_skills_checker is None and not missing
-            else ()
-        )
+        if missing_skills_checker is not None:
+            missing = missing_skills_checker(required)
+            skill_receipts = ()
+        else:
+            assert skill_bindings is not None
+            missing, skill_receipts = skill_bindings.evaluate(required)
+            if missing:
+                skill_receipts = ()
 
         resolution = ExtensionResolution(
             agent=agent,

--- a/tools/cc/src/cc/core/skill_store.py
+++ b/tools/cc/src/cc/core/skill_store.py
@@ -103,7 +103,9 @@ def knowledge_skill_paths() -> list[Path]:
     return [path for path, _source in resolve_knowledge_skill_sources()]
 
 
-def default_skill_paths() -> list[tuple[Path, str]]:
+def default_skill_paths(
+    *, knowledge_sources: Optional[list[tuple[Path, Any]]] = None
+) -> list[tuple[Path, str]]:
     """Return the default skill search paths with their source labels.
 
     Resolution order: project → machine → knowledge.
@@ -124,8 +126,15 @@ def default_skill_paths() -> list[tuple[Path, str]]:
         paths.append((machine_skills, "machine"))
 
     # Knowledge skills: every configured paths.knowledge_repo entry's
-    # 03-ai-enabling/01-skills/ tree (WP-372 P2.2).
-    for skills_dir in knowledge_skill_paths():
+    # 03-ai-enabling/01-skills/ tree (WP-372 P2.2). A caller that already
+    # verified the Knowledge ladder may provide those exact source roots so
+    # one operation does not recursively verify the same ladder again.
+    resolved_knowledge = (
+        [(path, None) for path in knowledge_skill_paths()]
+        if knowledge_sources is None
+        else knowledge_sources
+    )
+    for skills_dir, _source in resolved_knowledge:
         paths.append((skills_dir, "knowledge"))
 
     return paths
@@ -468,6 +477,7 @@ def discover_skills_with_sources(
     path_source_pairs: list[tuple[Path, str]],
     *,
     cache_dir: Optional[Path] = None,
+    _knowledge_sources: Optional[dict[Path, Any]] = None,
 ) -> list[SkillMeta]:
     """Discover skills from multiple paths, each with its own source label.
 
@@ -476,6 +486,10 @@ def discover_skills_with_sources(
 
     `cache_dir`: forwarded to `discover_skills()` unchanged -- `None` (the
     default) disables caching for every existing/direct caller.
+
+    `_knowledge_sources` is the internal caller-scoped authority seam for an
+    operation that already verified the Knowledge ladder. When supplied, a
+    Knowledge path absent from that exact mapping is skipped fail-closed.
     """
     seen_names: set[str] = set()
     results: list[SkillMeta] = []
@@ -484,19 +498,24 @@ def discover_skills_with_sources(
         knowledge_source = None
         effective_cache_dir = cache_dir
         if source_label == "knowledge":
-            from cc.core.ecosystem.knowledge_skill_source import (
-                resolve_knowledge_skill_sources,
-            )
-
             nominal = Path(os.path.abspath(Path(base_path).expanduser()))
-            knowledge_source = next(
-                (
-                    source
-                    for root, source in resolve_knowledge_skill_sources()
-                    if root == nominal
-                ),
-                None,
-            )
+            if _knowledge_sources is not None:
+                if nominal not in _knowledge_sources:
+                    continue
+                knowledge_source = _knowledge_sources[nominal]
+            else:
+                from cc.core.ecosystem.knowledge_skill_source import (
+                    resolve_knowledge_skill_sources,
+                )
+
+                knowledge_source = next(
+                    (
+                        source
+                        for root, source in resolve_knowledge_skill_sources()
+                        if root == nominal
+                    ),
+                    None,
+                )
             # A mutable mtime/size cache is not an authority for signed bytes.
             effective_cache_dir = None
         for skill in discover_skills(
@@ -557,6 +576,21 @@ def get_skill_content_with_receipt(
             Path(source.relative_path) / relative
         ).as_posix()
         receipt = source.authenticated_contribution(contribution, runtime=runtime)
+        return SkillContent(content=receipt.content, receipt=receipt)
+    return SkillContent(content=skill_meta.path.read_text(encoding="utf-8"))
+
+
+def get_skill_content_with_receipt_from_verified_batch(
+    skill_meta: SkillMeta, *, runtime: str = "cc"
+) -> SkillContent:
+    """Read a skill selected by the current caller-scoped verified batch."""
+    if skill_meta._knowledge_source is not None:
+        source = skill_meta._knowledge_source
+        relative = skill_meta.path.relative_to(source.skills_root)
+        contribution = (Path(source.relative_path) / relative).as_posix()
+        receipt = source.authenticated_contribution_from_verified_batch(
+            contribution, runtime=runtime
+        )
         return SkillContent(content=receipt.content, receipt=receipt)
     return SkillContent(content=skill_meta.path.read_text(encoding="utf-8"))
 

--- a/tools/cc/tests/conformance/fixtures/reference-install/manifest.json
+++ b/tools/cc/tests/conformance/fixtures/reference-install/manifest.json
@@ -2,7 +2,7 @@
   "_comment": "Golden-tree description for Layer 5's round-trip (and, per HARNESS-DESIGN.md section 5.2, reusable by Layer 3). Every field here was verified directly against VERSION.json and, where noted, a read-only inspection of the reference install on this machine -- never assumed from RUBRIC.md, which has two confirmed errors recorded below. See TEST-MATRIX.md section 5 'Ground truth constants'.",
   "generated_at": "2026-08-10",
   "verified_against": {
-    "version_json": "VERSION.json (framework 5.14.6, agents 5.6.0, commands 5.3.2)",
+    "version_json": "VERSION.json (framework 5.14.7, agents 5.6.0, commands 5.3.2)",
     "reference_install": "/Volumes/Dev/Sites/TSM/hermes (read-only inspection; no single repo is a complete reference -- hermes itself fails D3/D4/D7/D11/D12 per TEST-MATRIX.md)",
     "codex_plugin_source": "/Volumes/Dev/Sites/COPILOT/codex-copilot/plugins/codex-copilot (read-only file count)"
   },

--- a/tools/cc/tests/test_extensions_resolver.py
+++ b/tools/cc/tests/test_extensions_resolver.py
@@ -32,20 +32,24 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from types import SimpleNamespace
 
+import cc.core.ecosystem.knowledge_skill_source as knowledge_skill_source
+import cc.core.extensions_resolver as extensions_resolver
 import pytest
-from typer.testing import CliRunner
-
 from cc.core.extensions_resolver import (
     ACTION_APPLY,
     ACTION_FALLBACK_FAIL,
     ACTION_FALLBACK_USE_BASE,
     ACTION_FALLBACK_WARNING,
     ACTION_NO_EXTENSION,
+    ExtensionSkillBindings,
     compose_agent_content,
     resolve_extension,
 )
+from cc.core.skill_store import SkillMeta
 from cc.main import app
+from typer.testing import CliRunner
 
 runner = CliRunner()
 
@@ -296,6 +300,223 @@ def test_empty_knowledge_repos_list_returns_no_match():
     r = resolve_extension("sd", knowledge_repos=[])
     assert r.matched is False
     assert r.action == ACTION_NO_EXTENSION
+
+
+def test_prepare_source_bindings_verifies_protected_ladder_once(
+    monkeypatch, tmp_path
+):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    calls = 0
+
+    monkeypatch.setattr(
+        knowledge_skill_source,
+        "knowledge_repository_requires_authenticated_source",
+        lambda _repo: True,
+    )
+
+    def resolve_sources():
+        nonlocal calls
+        calls += 1
+        return [
+            (first, SimpleNamespace(repository_root=first)),
+            (second, SimpleNamespace(repository_root=second)),
+        ]
+
+    monkeypatch.setattr(
+        knowledge_skill_source, "resolve_knowledge_skill_sources", resolve_sources
+    )
+
+    bindings = extensions_resolver.prepare_extension_source_bindings(
+        [str(first), str(second)]
+    )
+
+    assert calls == 1
+    assert bindings[str(first.absolute())][0] is True
+    assert bindings[str(first.absolute())][1].repository_root == first
+    assert bindings[str(second.absolute())][0] is True
+    assert bindings[str(second.absolute())][1].repository_root == second
+
+
+def test_prepare_source_bindings_fails_closed_for_entire_protected_batch(
+    monkeypatch, tmp_path
+):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+
+    monkeypatch.setattr(
+        knowledge_skill_source,
+        "knowledge_repository_requires_authenticated_source",
+        lambda _repo: True,
+    )
+
+    def unavailable_sources():
+        raise RuntimeError("signed ladder unavailable")
+
+    monkeypatch.setattr(
+        knowledge_skill_source,
+        "resolve_knowledge_skill_sources",
+        unavailable_sources,
+    )
+
+    bindings = extensions_resolver.prepare_extension_source_bindings(
+        [str(first), str(second)]
+    )
+
+    assert bindings == {
+        str(first.absolute()): (True, None),
+        str(second.absolute()): (True, None),
+    }
+
+
+def test_resolve_extension_prepares_one_batch_for_multiple_repositories(monkeypatch):
+    calls = 0
+
+    def prepare(repos):
+        nonlocal calls
+        calls += 1
+        return {str(Path(repo).absolute()): (False, None) for repo in repos}
+
+    monkeypatch.setattr(
+        extensions_resolver, "prepare_extension_source_bindings", prepare
+    )
+
+    result = resolve_extension(
+        "cw",
+        knowledge_repos=[PERSONAL_REPO, ORG_REPO],
+        missing_skills_checker=_no_missing,
+    )
+
+    assert calls == 1
+    assert result.source_repo == PERSONAL_REPO
+
+
+def test_resolve_extension_uses_caller_batch_without_reverification(monkeypatch):
+    def unexpected_prepare(_repos):
+        raise AssertionError("caller-scoped bindings must be reused")
+
+    monkeypatch.setattr(
+        extensions_resolver,
+        "prepare_extension_source_bindings",
+        unexpected_prepare,
+    )
+    bindings = {
+        str(Path(PERSONAL_REPO).absolute()): (False, None),
+        str(Path(ORG_REPO).absolute()): (False, None),
+    }
+
+    result = resolve_extension(
+        "cw",
+        knowledge_repos=[PERSONAL_REPO, ORG_REPO],
+        missing_skills_checker=_no_missing,
+        source_bindings=bindings,
+    )
+
+    assert result.source_repo == PERSONAL_REPO
+
+
+def test_shared_skill_bindings_discover_required_skills_once(monkeypatch, tmp_path):
+    calls = 0
+    skills = [
+        SkillMeta(
+            name=name,
+            description="test skill",
+            path=tmp_path / name / "SKILL.md",
+        )
+        for name in ("moments-mapping", "cocreate-sprint", "accessibility")
+    ]
+
+    monkeypatch.setattr(
+        "cc.core.skill_store.default_skill_paths", lambda **_kwargs: []
+    )
+
+    def discover(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return skills
+
+    monkeypatch.setattr("cc.core.skill_store.discover_skills_with_sources", discover)
+    source_bindings = {
+        str(Path(PERSONAL_REPO).absolute()): (False, None),
+        str(Path(ORG_REPO).absolute()): (False, None),
+    }
+    skill_bindings = ExtensionSkillBindings(
+        (PERSONAL_REPO, ORG_REPO), source_bindings
+    )
+
+    sd = resolve_extension(
+        "sd",
+        knowledge_repos=[PERSONAL_REPO, ORG_REPO],
+        source_bindings=source_bindings,
+        skill_bindings=skill_bindings,
+    )
+    uxd = resolve_extension(
+        "uxd",
+        knowledge_repos=[PERSONAL_REPO, ORG_REPO],
+        source_bindings=source_bindings,
+        skill_bindings=skill_bindings,
+    )
+
+    assert sd.action == ACTION_APPLY
+    assert uxd.action == ACTION_APPLY
+    assert calls == 1
+
+
+def test_skill_binding_receipt_failure_marks_authenticated_skill_missing(
+    monkeypatch, tmp_path
+):
+    source = object()
+    skill = SkillMeta(
+        name="secure-skill",
+        description="test skill",
+        path=tmp_path / "secure-skill" / "SKILL.md",
+        _knowledge_source=source,
+    )
+    bindings = ExtensionSkillBindings((), {})
+    bindings._skills = [skill]
+
+    def unavailable_receipt(*_args, **_kwargs):
+        raise RuntimeError("entitlement changed")
+
+    monkeypatch.setattr(
+        "cc.core.skill_store.get_skill_content_with_receipt_from_verified_batch",
+        unavailable_receipt,
+    )
+
+    missing, receipts = bindings.evaluate(["secure-skill"])
+
+    assert missing == ["secure-skill"]
+    assert receipts == ()
+
+
+def test_resolve_extension_missing_caller_binding_fails_closed(monkeypatch):
+    def unexpected_lookup(*_args, **_kwargs):
+        raise AssertionError("missing batch keys must not trigger live lookup")
+
+    monkeypatch.setattr(
+        knowledge_skill_source,
+        "knowledge_repository_requires_authenticated_source",
+        unexpected_lookup,
+    )
+    monkeypatch.setattr(
+        knowledge_skill_source,
+        "resolve_knowledge_skill_sources",
+        unexpected_lookup,
+    )
+
+    result = resolve_extension(
+        "cw",
+        knowledge_repos=[PERSONAL_REPO],
+        missing_skills_checker=_no_missing,
+        source_bindings={},
+    )
+
+    assert result.matched is False
+    assert result.action == ACTION_NO_EXTENSION
 
 
 # ---------------------------------------------------------------------------

--- a/tools/cc/tests/test_knowledge_skill_source.py
+++ b/tools/cc/tests/test_knowledge_skill_source.py
@@ -639,6 +639,53 @@ def test_signed_release_blob_read_ignores_checkout_and_tag_switch(signed_source)
     assert source.release.read_blob(".claude/extensions/do.extension.md") == expected
 
 
+def test_verified_batch_contribution_uses_selected_immutable_source(
+    signed_source, monkeypatch
+):
+    repo, _fingerprint = signed_source
+    source = _discover_signed()._knowledge_source
+    (repo / ".claude/extensions/do.extension.md").write_text(
+        "mutable checkout replacement\n", encoding="utf-8"
+    )
+
+    def unexpected_revalidation(_source):
+        raise AssertionError("verified batch reads must not resolve the ladder again")
+
+    monkeypatch.setattr(
+        "cc.core.ecosystem.knowledge_skill_source.revalidate_knowledge_skill_source",
+        unexpected_revalidation,
+    )
+
+    receipt = source.authenticated_contribution_from_verified_batch(
+        ".claude/extensions/do.extension.md", runtime="claude"
+    )
+
+    assert receipt.content == "signed extension body\n"
+    assert receipt.is_authenticated is True
+
+
+def test_protected_verified_batch_read_fails_when_entitlement_changes(
+    protected_signed_source,
+):
+    _repo, layer, state_path, _cache_root = protected_signed_source
+    source = _discover_signed()._knowledge_source
+    assert source.entitlement_binding is not None
+
+    decision = entitlement.observe_layer(
+        layer,
+        login="person",
+        token="token",
+        get_json=lambda *_args, **_kwargs: 404,
+        state_path=state_path,
+    )
+
+    assert decision.state == "revoked"
+    with pytest.raises(KnowledgeSkillSourceError, match="authorization changed"):
+        source.authenticated_contribution_from_verified_batch(
+            ".claude/extensions/do.extension.md", runtime="claude"
+        )
+
+
 def test_existing_resolver_composes_signed_extension_with_receipt(signed_source):
     repo, _fingerprint = signed_source
     resolution = resolve_extension("do", knowledge_repos=[str(repo)])


### PR DESCRIPTION
## Outcome

Makes signed Knowledge extension resolution operational for direct Claude Code and Codex use by verifying one caller-scoped source and skill batch per command.

## Security properties

- No global verification cache.
- Every new command revalidates the configured signed Knowledge ladder.
- Protected repositories remain fail-closed when classification or signed-source resolution fails.
- Contribution reads use immutable signed Git object bytes.
- Protected contribution and skill reads remain serialized under the exact entitlement binding lease.
- Missing batch keys and authenticated skill receipt failures fail closed.

## Performance evidence

- Single real signed cco resolution: approximately 44 seconds before, 9.6 seconds after.
- Real aggregate H1/H2 tier collection: exceeded 175 seconds before termination, 28.5 seconds after.
- Aggregate result after: 13 pass, 1 legitimate skip, 0 fail, 0 could-not-run.

## QA

- Full portable cc suite: 3,004 passed, 46 machine-only deselected.
- Focused extension, signed-source, skill-store, and tier tests passed.
- Static eval: all 16 agents, 154/154 cases passed.
- Smoke: 70/70 passed.
- Version consistency and changed-file Ruff checks passed.
- git diff --check passed.

## Release

Bumps framework to 5.14.7 and cc to 2.12.10.