### PR TITLE
fix(cc): complete fleet classification

### DIFF
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,6 +1,6 @@
 {
-  "framework": "5.14.7",
-  "lastUpdated": "2026-08-14T00:00:00.000Z",
+  "framework": "5.14.8",
+  "lastUpdated": "2026-08-14T17:15:00.000Z",
   "components": {
     "cc": {
       "version": "2.12.10",

--- a/copilot.lock.json
+++ b/copilot.lock.json
@@ -130,8 +130,8 @@
         }
       ],
       "ownership_mode": "full",
-      "release_tag": "v5.14.7",
-      "version": "5.14.7"
+      "release_tag": "v5.14.8",
+      "version": "5.14.8"
     },
     {
       "component": "codex",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilot/framework",
-  "version": "5.14.7",
+  "version": "5.14.8",
   "description": "Claude Copilot - AI-enabled development framework",
   "private": true,
   "scripts": {

--- a/tools/cc/classification.toml
+++ b/tools/cc/classification.toml
@@ -174,6 +174,11 @@ class = "PRODUCT"
 rationale = "CLASSIFICATION.md #20: flagship AI relationship-intelligence platform."
 
 [[repos]]
+path = "COPILOT/convoco-google-verification"
+class = "PRODUCT"
+rationale = "Live Git product repository discovered by canonical reconciliation and conformance on 2026-08-14; explicit classification closes the fleet-census omission."
+
+[[repos]]
 path = "COPILOT/copilot-news"
 class = "PRODUCT"
 rationale = "Q27 owner answer 'product' (confirmed CLASSIFICATION.md #21's PRODUCT assignment over the competing SCRATCH/ARCHIVE reading)."

--- a/tools/cc/tests/conformance/test_layer3_dimensions.py
+++ b/tools/cc/tests/conformance/test_layer3_dimensions.py
@@ -300,12 +300,11 @@ class TestRealClassificationToml:
     def real_table(self):
         return classes.load_classification_table()
 
-    def test_has_reviewed_audit_entries_plus_deferred_app_disposition(
-        self, real_table
-    ):
+    def test_has_reviewed_audit_entries_plus_deferred_app_disposition(self, real_table):
         # 75 real directories from the 2026-08-10 audit, plus the app-only
-        # public repo discovered afterward and explicitly deferred to PRD-24.
-        assert len(real_table) == 76
+        # public repo discovered afterward and explicitly deferred to PRD-24,
+        # then one active Git root omitted from that static audit.
+        assert len(real_table) == 77
 
     def test_every_entry_has_a_valid_rubric_letter(self, real_table):
         for key, entry in real_table.items():
@@ -316,7 +315,7 @@ class TestRealClassificationToml:
 
         counts = Counter(entry.repo_class for entry in real_table.values())
         assert counts[RepoClass.COMPONENT] == 17
-        assert counts[RepoClass.PRODUCT] == 35
+        assert counts[RepoClass.PRODUCT] == 36
         assert counts[RepoClass.SITE_CONTENT] == 8
         assert counts[RepoClass.DOCS_KNOWLEDGE] == 1
         assert counts[RepoClass.SCRATCH_ARCHIVE] == 15
@@ -366,6 +365,12 @@ class TestRealClassificationToml:
             "investr-api",
         ):
             assert real_table[f"PERSONAL/{name}"].repo_class is RepoClass.PRODUCT
+
+    def test_live_product_omission_is_explicitly_classified(self, real_table):
+        assert (
+            real_table["COPILOT/convoco-google-verification"].repo_class
+            is RepoClass.PRODUCT
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Outcome

Adds the live `convoco-google-verification` product repository to the canonical fleet classification so reconciliation and conformance operate over the same explicit repository set.

## Verification

- Full portable cc suite: passed (`pytest -m "not machine_only"`)
- Classification conformance tests: passed
- Ruff: passed
- Smoke suite: 70/70
- Version consistency: passed
- Diff check: passed

## Release

Framework v5.14.8; cc remains v2.12.10.