### PR TITLE
fix(journey): restore agent dispatch verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Journey verifier runtime availability (framework 5.14.9):** snapshot and frozen `cc` installs now embed Task Copilot's public evidence API, and a project with no `tasks.db` is correctly proven to have no active journey for an unframed agent dispatch while any supplied journey marker still fails closed.
+
 - **Accurate setup support status (`cc` 2.11.1):** a successful preparation
   phase that discovers a separate machine blocker is reported as
   `action-required`, not as a partially failed preparation. Foundation,

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,6 +1,6 @@
 {
-  "framework": "5.14.8",
-  "lastUpdated": "2026-08-14T17:15:00.000Z",
+  "framework": "5.14.9",
+  "lastUpdated": "2026-08-14T18:06:06.000Z",
   "components": {
     "cc": {
       "version": "2.12.10",

--- a/copilot.lock.json
+++ b/copilot.lock.json
@@ -130,8 +130,8 @@
         }
       ],
       "ownership_mode": "full",
-      "release_tag": "v5.14.8",
-      "version": "5.14.8"
+      "release_tag": "v5.14.9",
+      "version": "5.14.9"
     },
     {
       "component": "codex",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilot/framework",
-  "version": "5.14.8",
+  "version": "5.14.9",
   "description": "Claude Copilot - AI-enabled development framework",
   "private": true,
   "scripts": {

--- a/scripts/package-cc-macos-release.sh
+++ b/scripts/package-cc-macos-release.sh
@@ -250,7 +250,7 @@ run_python() {
         PYTHONHOME="${python_root}" \
         DYLD_FRAMEWORK_PATH="${framework_shim}" \
         DYLD_LIBRARY_PATH="${python_root}/lib" \
-        PYTHONPATH="${site_packages:-}:${source_checkout}/tools/cc/src" \
+        PYTHONPATH="${site_packages:-}:${source_checkout}/tools/cc/src:${source_checkout}/tools/tc/src" \
         "${python_executable}" "$@"
 }
 
@@ -344,7 +344,9 @@ run_python -m PyInstaller \
     --target-arch universal2 \
     --codesign-identity "${CT_SIGN_IDENTITY}" \
     --paths "${source_checkout}/tools/cc/src" \
+    --paths "${source_checkout}/tools/tc/src" \
     --paths "${site_packages}" \
+    --hidden-import "tc.api" \
     --distpath "${pyinstaller_dist}" \
     --workpath "${scratch}/pyinstaller-work" \
     --specpath "${scratch}/pyinstaller-spec" \

--- a/tools/cc/install.sh
+++ b/tools/cc/install.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_DIR="$SCRIPT_DIR/.venv"
+TC_DIR="$SCRIPT_DIR/../tc"
 SHIM="$HOME/.local/bin/cc"
 UPDATE_PROFILES=1
 
@@ -76,10 +77,22 @@ if ! "$VENV_DIR/bin/python" -m pip --version >/dev/null 2>&1; then
     "$VENV_DIR/bin/python" -m ensurepip --upgrade >/dev/null
 fi
 
-# Step 2: Install/upgrade pip and install cc in editable mode
+# Step 2: Install/upgrade pip and install the runtime packages in editable mode.
+# cc journey uses Task Copilot's public Python API as its durable evidence
+# ledger. Installing only cc leaves every Agent dispatch unable to distinguish
+# "no active journey" from "verifier unavailable" and therefore fail-closed.
 echo "==> Installing cc in editable mode"
+if [ ! -f "$TC_DIR/pyproject.toml" ]; then
+    echo "ERROR: Bundled Task Copilot package not found at $TC_DIR" >&2
+    exit 1
+fi
 "$VENV_DIR/bin/python" -m pip install --quiet --upgrade pip
+"$VENV_DIR/bin/python" -m pip install --quiet -e "$TC_DIR"
 "$VENV_DIR/bin/python" -m pip install --quiet -e "$SCRIPT_DIR"
+"$VENV_DIR/bin/python" -c 'import tc.api' || {
+    echo "ERROR: cc runtime cannot import the Task Copilot evidence API" >&2
+    exit 1
+}
 
 # Step 3: Ensure shim directory exists
 mkdir -p "$SHIM_DIR"

--- a/tools/cc/src/cc/core/evaluation/journey_runtime.py
+++ b/tools/cc/src/cc/core/evaluation/journey_runtime.py
@@ -1320,6 +1320,27 @@ def verify_dispatch(
         raise ValueError("dispatch-arguments-malformed") from exc
     if not _DIGEST.fullmatch(prompt_sha256):
         raise ValueError("dispatch-arguments-malformed")
+    if ledger_factory is TcJourneyLedger:
+        try:
+            from tc.db.connection import find_db_path
+        except ImportError as exc:
+            raise RuntimeError(
+                "Task Copilot is unavailable; journey state cannot continue."
+            ) from exc
+        try:
+            task_db = find_db_path()
+        except OSError as exc:
+            raise RuntimeError(
+                "Task Copilot state could not be inspected."
+            ) from exc
+        if task_db is None:
+            # With no durable ledger, no active journey can exist. An
+            # unframed legacy dispatch is therefore provably no-active. A
+            # supplied marker is still rejected: accepting one without its
+            # evidence would turn absence of state into an authority bypass.
+            if marker:
+                raise ValueError("dispatch-marker-stale-or-ambiguous")
+            return {"schema_version": RUNTIME_SCHEMA_VERSION, "state": "no_active"}
     probe = ledger_factory(0)
     if not marker:
         if _active_runs_for_session(session_id, probe):

--- a/tools/cc/tests/evaluation/test_journey_runtime.py
+++ b/tools/cc/tests/evaluation/test_journey_runtime.py
@@ -384,6 +384,30 @@ def test_no_active_legacy_and_missing_wrong_or_replayed_markers():
         )
 
 
+def test_default_verifier_proves_no_active_without_task_database(
+    tmp_path, monkeypatch
+):
+    monkeypatch.syspath_prepend(str(Path("tools/tc/src").resolve()))
+    monkeypatch.chdir(tmp_path)
+
+    assert verify_dispatch(
+        session_id="database-free-session",
+        specialist="qa",
+        marker="",
+        prompt_sha256="c" * 64,
+        knowledge_sha256="",
+    ) == {"schema_version": "2.1", "state": "no_active"}
+
+    with pytest.raises(ValueError, match="dispatch-marker-stale-or-ambiguous"):
+        verify_dispatch(
+            session_id="database-free-session",
+            specialist="qa",
+            marker="a" * 48,
+            prompt_sha256="c" * 64,
+            knowledge_sha256="d" * 64,
+        )
+
+
 def test_completed_dispatch_replay_denies_without_security_or_knowledge():
     rows = Rows()
     started = begin(rows, specialists=("me",))

--- a/tools/cc/tests/test_install_script_contract.py
+++ b/tools/cc/tests/test_install_script_contract.py
@@ -18,3 +18,20 @@ def test_installer_supports_transactional_shim_staging_without_profile_edits():
     assert "--no-profile-update" in source
     assert 'SHIM_DIR="$(dirname "$SHIM")"' in source
     assert 'if [ "$UPDATE_PROFILES" -eq 1 ]' in source
+
+
+def test_installer_embeds_task_copilot_api_required_by_journey_verifier():
+    source = (Path(__file__).parents[1] / "install.sh").read_text(encoding="utf-8")
+
+    assert 'TC_DIR="$SCRIPT_DIR/../tc"' in source
+    assert 'pip install --quiet -e "$TC_DIR"' in source
+    assert "-c 'import tc.api'" in source
+
+
+def test_frozen_release_embeds_task_copilot_api_required_by_journey_verifier():
+    script = (
+        Path(__file__).parents[3] / "scripts/package-cc-macos-release.sh"
+    ).read_text(encoding="utf-8")
+
+    assert '${source_checkout}/tools/tc/src' in script
+    assert '--hidden-import "tc.api"' in script

--- a/tools/tc/src/tc/api.py
+++ b/tools/tc/src/tc/api.py
@@ -9,8 +9,11 @@ task/PRD/work-product operations in a single python3 block.  All functions:
     one transaction (use ``transaction()`` as context manager).
   - Are import-side-effect-free: no DB opened, no env read at import time.
 
-CRITICAL: tc and cc live in separate installed environments.  Keep each
-code-execution block scoped to ONE tool (tc-only OR cc-only).
+CRITICAL: Keep each user-authored code-execution block scoped to ONE tool
+(tc-only OR cc-only). The framework snapshot installer also embeds this public
+API in cc's private environment because journey verification uses Task Copilot
+as its durable evidence ledger; that internal runtime binding does not make
+mixed user-authored tc/cc API blocks safe.
 
 Usage pattern — "create PRD + N tasks + wire dependencies" (one Bash call):
     python3 - << 'PY'


### PR DESCRIPTION
Restores framework-agent dispatch across projects. Snapshot cc installs now embed the Task Copilot evidence API. Projects without a tasks.db prove no active journey for unframed dispatches, while supplied journey markers still fail closed. Includes clean-install, verifier, hook, portable cc, Task Copilot, smoke, and version-contract coverage.