### PR TITLE
fix(cc): reconcile authoritative project source drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Authoritative project source drift (framework 5.14.10):** verified full-ownership Claude and Codex installations now detect a newer authoritative framework contract, offer a bounded safe update only when the project is stable, preserve unrelated project work, stop for path collisions or retired framework paths, and become a zero-work ready state after application. Customized-preservation locks compare only their recorded ownership boundary and require owner review when that boundary becomes stale instead of being promoted to full framework ownership.
+
 - **Journey verifier runtime availability (framework 5.14.9):** snapshot and frozen `cc` installs now embed Task Copilot's public evidence API, and a project with no `tasks.db` is correctly proven to have no active journey for an unframed agent dispatch while any supplied journey marker still fails closed.
 
 - **Accurate setup support status (`cc` 2.11.1):** a successful preparation

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,6 +1,6 @@
 {
-  "framework": "5.14.9",
-  "lastUpdated": "2026-08-14T18:06:06.000Z",
+  "framework": "5.14.10",
+  "lastUpdated": "2026-08-14T18:22:00.000Z",
   "components": {
     "cc": {
       "version": "2.12.10",

--- a/copilot.lock.json
+++ b/copilot.lock.json
@@ -130,8 +130,8 @@
         }
       ],
       "ownership_mode": "full",
-      "release_tag": "v5.14.9",
-      "version": "5.14.9"
+      "release_tag": "v5.14.10",
+      "version": "5.14.10"
     },
     {
       "component": "codex",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilot/framework",
-  "version": "5.14.9",
+  "version": "5.14.10",
   "description": "Claude Copilot - AI-enabled development framework",
   "private": true,
   "scripts": {

--- a/tools/cc/src/cc/core/ecosystem/project_reconciliation.py
+++ b/tools/cc/src/cc/core/ecosystem/project_reconciliation.py
@@ -33,11 +33,13 @@ from cc.core.ecosystem.project_locking import (
 )
 from cc.core.ecosystem.reconciliation_recipes import (
     DEFAULT_RECIPE_REGISTRY,
+    ComponentSourceConflict,
     RecipePlan,
     RecipeValidationError,
     allowed_targets_for_components,
     authoritative_source_available,
     build_recipe_plan,
+    component_lock_update_required,
 )
 from cc.core.ecosystem.reconciliation_types import (
     SUPPORTED_COMPONENTS,
@@ -1053,9 +1055,13 @@ def assess_project(
         for component in SUPPORTED_COMPONENTS
     }
     components: list[ComponentAssessment] = []
+    source_drift_held = False
     for component in SUPPORTED_COMPONENTS:
         draft = underlying[component]
         is_selected = component in selected
+        source_drift = False
+        source_conflict = False
+        source_comparison_failed = False
         route = _component_route(
             draft,
             selected=is_selected,
@@ -1064,6 +1070,25 @@ def assess_project(
             unstable=unstable,
             ready_repeat_safe=ready_repeat_safe,
         )
+        if route == ComponentRoute.READY:
+            try:
+                source_drift = component_lock_update_required(path, component)
+            except ComponentSourceConflict:
+                source_conflict = True
+                route = ComponentRoute.OWNER_DECISION
+            except RecipeValidationError:
+                source_comparison_failed = True
+                route = ComponentRoute.SOURCE_UNAVAILABLE
+            else:
+                if source_drift:
+                    route = (
+                        ComponentRoute.HELD
+                        if unstable
+                        else ComponentRoute.SAFE_UPDATE_AVAILABLE
+                    )
+                    source_drift_held = (
+                        source_drift_held or route == ComponentRoute.HELD
+                    )
         if _requires_owner_for_unreadable_config(path, component, draft, route):
             route = ComponentRoute.OWNER_DECISION
         if route in {
@@ -1095,7 +1120,42 @@ def assess_project(
             "recommended": recommended,
             "recommendation_reason": reason,
             "responsible_actor": _ACTOR[route],
-            "evidence": _component_evidence(draft),
+            "evidence": [
+                *_component_evidence(draft),
+                *(
+                    [
+                        {
+                            "id": f"{component}-authoritative-source",
+                            "state": "update-available",
+                            "detail": f"The verified {component.title()} project lock differs from the current authoritative source contract.",
+                        }
+                    ]
+                    if source_drift
+                    else []
+                ),
+                *(
+                    [
+                        {
+                            "id": f"{component}-authoritative-source",
+                            "state": "conflict",
+                            "detail": f"The current authoritative {component.title()} source would collide with content outside the verified framework-owned update boundary.",
+                        }
+                    ]
+                    if source_conflict
+                    else []
+                ),
+                *(
+                    [
+                        {
+                            "id": f"{component}-authoritative-source",
+                            "state": "unavailable",
+                            "detail": f"The current authoritative {component.title()} source contract could not be verified.",
+                        }
+                    ]
+                    if source_comparison_failed
+                    else []
+                ),
+            ],
             "missing_requirements": _component_missing(draft),
             "next_action": _component_next_action(route, component),
             "recipe_options": [],
@@ -1171,7 +1231,7 @@ def assess_project(
                 "Remove the exclusion only after a person explicitly opts in.",
             )
         )
-    if dirty and not ready_repeat_safe:
+    if dirty and (not ready_repeat_safe or source_drift_held):
         blockers.append(
             _blocker(
                 "dirty-working-tree",

--- a/tools/cc/src/cc/core/ecosystem/reconciliation_recipes.py
+++ b/tools/cc/src/cc/core/ecosystem/reconciliation_recipes.py
@@ -48,6 +48,10 @@ class RecipeValidationError(ValueError):
     """A recipe is unknown, mismatched, or outside the typed safety boundary."""
 
 
+class ComponentSourceConflict(RecipeValidationError):
+    """A current source update would collide with unowned project content."""
+
+
 _FINGERPRINT_PREFIX = "sha256:"
 
 _COMMON_TARGETS = (
@@ -1545,6 +1549,43 @@ def _claude_legacy(root: Path, component: str) -> tuple[RecipeOperation, ...]:
     )
 
 
+def _claude_update(root: Path, component: str) -> tuple[RecipeOperation, ...]:
+    source = _source_root(component)
+    operations = list(_claude_setup(root, component))
+    planned_targets = {operation.target for operation in operations}
+    desired = _lock_entry(source, component)
+    for item in desired["files"]:
+        target = str(item["path"])
+        if target in planned_targets:
+            continue
+        try:
+            current = _bytes_hash((root / target).read_bytes())
+        except OSError:
+            current = None
+        if current == item["checksum"]:
+            continue
+        operation = _operation(
+            root=root,
+            component=component,
+            kind=RecipeOperationKind.COPY_FILE_FROM_SOURCE,
+            target=target,
+            description=f"Refresh the verified framework-owned {target} file.",
+            source=source / target,
+            payload={
+                "source_path": str(source / target),
+                "mode": 0o755 if target.endswith(".sh") else 0o644,
+            },
+        )
+        lock_index = next(
+            index
+            for index, existing in enumerate(operations)
+            if existing.kind == RecipeOperationKind.UPSERT_LOCK_COMPONENT
+        )
+        operations.insert(lock_index, operation)
+        planned_targets.add(target)
+    return tuple(operations)
+
+
 def _codex_setup(root: Path, component: str) -> tuple[RecipeOperation, ...]:
     source = _source_root(component)
     binding = _codex_plugin_binding(root)
@@ -1646,6 +1687,89 @@ def _codex_setup(root: Path, component: str) -> tuple[RecipeOperation, ...]:
             ),
         )
     )
+    return tuple(operations)
+
+
+def _codex_update(root: Path, component: str) -> tuple[RecipeOperation, ...]:
+    source = _source_root(component)
+    binding = _codex_plugin_binding(root)
+    operations = list(_codex_setup(root, component))
+    planned_targets = {operation.target for operation in operations}
+    desired = _lock_entry(source, component, codex_binding=binding)
+    existing = _existing_lock_entries(root).get(component, {})
+    desired_files = {
+        str(item["path"]): str(item["checksum"]) for item in desired["files"]
+    }
+    existing_files = {
+        str(item["path"]): str(item["checksum"])
+        for item in existing.get("files", [])
+        if isinstance(item, Mapping)
+    }
+    insertions: list[RecipeOperation] = []
+    desired_plugin = {
+        path: checksum
+        for path, checksum in desired_files.items()
+        if path.startswith("plugins/codex-copilot/")
+    }
+    existing_plugin = {
+        path: checksum
+        for path, checksum in existing_files.items()
+        if path.startswith("plugins/codex-copilot/")
+    }
+    if (
+        desired_plugin != existing_plugin
+        and "plugins/codex-copilot" not in planned_targets
+    ):
+        plugin_source = (
+            binding.path if binding is not None else source / "plugins/codex-copilot"
+        )
+        insertions.append(
+            _operation(
+                root=root,
+                component=component,
+                kind=RecipeOperationKind.COPY_TREE_FROM_SOURCE,
+                target="plugins/codex-copilot",
+                description="Refresh the verified portable project-local Codex plugin copy.",
+                source=plugin_source,
+                source_fingerprint_override=(
+                    binding.snapshot.fingerprint() if binding is not None else None
+                ),
+                payload={
+                    "source_path": str(plugin_source),
+                    **(
+                        {"source_provenance": binding.provenance()}
+                        | {
+                            "source_repository_root": str(binding.repository_root),
+                            "source_relative_path": binding.relative_path,
+                        }
+                        if binding is not None
+                        else {}
+                    ),
+                },
+            )
+        )
+    gate = "scripts/copilot-gate.sh"
+    if (
+        desired_files.get(gate) != existing_files.get(gate)
+        and gate not in planned_targets
+    ):
+        insertions.append(
+            _operation(
+                root=root,
+                component=component,
+                kind=RecipeOperationKind.COPY_FILE_FROM_SOURCE,
+                target=gate,
+                description="Refresh the verified project-local Codex gate.",
+                source=source / gate,
+                payload={"source_path": str(source / gate), "mode": 0o755},
+            )
+        )
+    lock_index = next(
+        index
+        for index, operation in enumerate(operations)
+        if operation.kind == RecipeOperationKind.UPSERT_LOCK_COMPONENT
+    )
+    operations[lock_index:lock_index] = insertions
     return tuple(operations)
 
 
@@ -2217,13 +2341,13 @@ DEFAULT_RECIPE_REGISTRY = RecipeRegistry(
             "claude-repair-known-v1",
             "claude",
             frozenset({ComponentRoute.SAFE_UPDATE_AVAILABLE}),
-            _claude_setup,
+            _claude_update,
         ),
         RecipeDefinition(
             "codex-repair-known-v1",
             "codex",
             frozenset({ComponentRoute.SAFE_UPDATE_AVAILABLE}),
-            _codex_setup,
+            _codex_update,
         ),
         RecipeDefinition(
             "claude.customized-preserve-entry.v1",
@@ -2430,6 +2554,151 @@ def _existing_lock_entries(root: Path) -> dict[str, dict[str, Any]]:
     return result
 
 
+def _normalized_component_contract(entry: Mapping[str, Any]) -> dict[str, Any]:
+    files = entry.get("files")
+    normalized_files = (
+        sorted(
+            (dict(item) for item in files if isinstance(item, Mapping)),
+            key=lambda item: str(item.get("path", "")),
+        )
+        if isinstance(files, list)
+        else []
+    )
+    return {
+        "component": entry.get("component"),
+        "version": entry.get("version"),
+        "release_tag": entry.get("release_tag"),
+        "ownership_mode": entry.get("ownership_mode"),
+        "files": normalized_files,
+        "provenance": entry.get("provenance"),
+    }
+
+
+def _verified_update_boundary(
+    root: Path,
+    component: str,
+    existing: Mapping[str, Any],
+    desired: Mapping[str, Any],
+) -> None:
+    existing_files = {
+        str(item["path"]): str(item["checksum"])
+        for item in existing.get("files", [])
+        if isinstance(item, Mapping)
+        and isinstance(item.get("path"), str)
+        and isinstance(item.get("checksum"), str)
+    }
+    desired_files = {
+        str(item["path"]): str(item["checksum"])
+        for item in desired.get("files", [])
+        if isinstance(item, Mapping)
+        and isinstance(item.get("path"), str)
+        and isinstance(item.get("checksum"), str)
+    }
+    retired = set(existing_files) - set(desired_files)
+    if retired:
+        raise ComponentSourceConflict(
+            "The authoritative source retires framework paths that require an owner-reviewed disposition."
+        )
+    for relative in set(desired_files) - set(existing_files):
+        target = root / relative
+        try:
+            metadata = target.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise ComponentSourceConflict(
+                "A newly managed framework path could not be inspected safely."
+            ) from exc
+        try:
+            conflicts = (
+                stat.S_ISLNK(metadata.st_mode)
+                or not stat.S_ISREG(metadata.st_mode)
+                or _bytes_hash(target.read_bytes()) != desired_files[relative]
+            )
+        except OSError as exc:
+            raise ComponentSourceConflict(
+                "A newly managed framework path could not be inspected safely."
+            ) from exc
+        if conflicts:
+            raise ComponentSourceConflict(
+                "A newly managed framework path conflicts with existing project content."
+            )
+    if component != "codex" or existing.get("ownership_mode") == "customized-preserve":
+        return
+    plugin = root / "plugins/codex-copilot"
+    recorded_plugin_paths = {
+        path for path in existing_files if path.startswith("plugins/codex-copilot/")
+    }
+    try:
+        actual_plugin_paths = {
+            path.relative_to(root).as_posix()
+            for path in plugin.rglob("*")
+            if path.is_file() and not path.is_symlink()
+        }
+        unsafe_plugin_entry = any(path.is_symlink() for path in plugin.rglob("*"))
+    except OSError as exc:
+        raise ComponentSourceConflict(
+            "The current project-local Codex plugin could not be inspected safely."
+        ) from exc
+    if unsafe_plugin_entry or actual_plugin_paths != recorded_plugin_paths:
+        raise ComponentSourceConflict(
+            "The current project-local Codex plugin contains content outside its verified lock boundary."
+        )
+
+
+def _desired_component_contract(
+    root: Path, component: str, existing: Mapping[str, Any]
+) -> dict[str, Any]:
+    binding = _codex_plugin_binding(root) if component == "codex" else _BINDING_UNSET
+    desired = _lock_entry(_source_root(component), component, codex_binding=binding)
+    if existing.get("ownership_mode") != "customized-preserve":
+        return desired
+
+    owned_paths = {
+        str(item["path"])
+        for item in existing.get("files", [])
+        if isinstance(item, Mapping) and isinstance(item.get("path"), str)
+    }
+    desired["ownership_mode"] = "customized-preserve"
+    desired["files"] = [
+        item for item in desired["files"] if str(item.get("path", "")) in owned_paths
+    ]
+    if component == "codex" and "provenance" not in existing:
+        desired.pop("provenance", None)
+    return desired
+
+
+def component_lock_update_required(root: Path, component: str) -> bool:
+    """Return whether a verified lock differs from today's effective source.
+
+    The integration inspector proves the existing lock against disk. This
+    comparison answers the independent question needed by reconciliation:
+    whether the verified installation is still the exact installation the
+    current authoritative source would produce. Managed-output fingerprints
+    are deliberately excluded because the recipe preserves and recomputes
+    them around project-owned merge targets.
+
+    A missing component entry returns ``False`` because the integration
+    inspector owns setup/repair classification. Callers use this only after
+    that inspector has classified a component as ready.
+    """
+    if component not in SUPPORTED_COMPONENTS:
+        raise RecipeValidationError("The component lock comparison is unsupported.")
+    existing = _existing_lock_entries(root).get(component)
+    if existing is None:
+        return False
+    desired = _desired_component_contract(root, component, existing)
+    _verified_update_boundary(root, component, existing, desired)
+    update_required = _normalized_component_contract(
+        existing
+    ) != _normalized_component_contract(desired)
+    if update_required and existing.get("ownership_mode") == "customized-preserve":
+        raise ComponentSourceConflict(
+            "The customized framework boundary differs from the authoritative source and requires owner review."
+        )
+    return update_required
+
+
 def _managed_records(entry: Mapping[str, Any]) -> list[dict[str, str]]:
     records = entry.get("managed_outputs", [])
     if not isinstance(records, list):
@@ -2626,9 +2895,7 @@ def build_recipe_plan(
         for definition, component_ops in built
     )
     if codex_mutating:
-        resolved_binding, private_bindings = (
-            resolve_codex_plugin_source_with_bindings()
-        )
+        resolved_binding, private_bindings = resolve_codex_plugin_source_with_bindings()
         expected_provenance = (
             resolved_binding.provenance() if resolved_binding is not None else None
         )
@@ -2648,7 +2915,9 @@ def build_recipe_plan(
             for entry in entries:
                 if isinstance(entry, Mapping) and entry.get("component") == "codex":
                     value = entry.get("provenance")
-                    planned_provenance = dict(value) if isinstance(value, Mapping) else None
+                    planned_provenance = (
+                        dict(value) if isinstance(value, Mapping) else None
+                    )
         if planned_provenance != expected_provenance:
             raise RecipeValidationError(
                 "The effective Codex entitlement changed while the recipe was being prepared."
@@ -2704,8 +2973,10 @@ __all__ = [
     "RecipePlan",
     "RecipeRegistry",
     "RecipeValidationError",
+    "ComponentSourceConflict",
     "allowed_targets_for_components",
     "authoritative_source_available",
     "build_recipe_plan",
+    "component_lock_update_required",
     "validated_source_root",
 ]

--- a/tools/cc/tests/test_project_reconciliation.py
+++ b/tools/cc/tests/test_project_reconciliation.py
@@ -8,14 +8,13 @@ from typing import Any
 
 import jsonschema
 import pytest
+from cc.core.ecosystem import project_reconciliation as reconciliation
 from cc.core.ecosystem.project_reconciliation import (
     ProjectReconciliationError,
     assess_project,
     build_project_census,
     build_project_plans,
 )
-
-from cc.core.ecosystem import project_reconciliation as reconciliation
 
 FIXTURES = Path(__file__).parent / "fixtures/project-reconciliation/cases.json"
 SCHEMA = Path(__file__).parent / "fixtures/schemas/reconcile.schema.json"
@@ -132,6 +131,9 @@ def stable_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     monkeypatch.setattr(reconciliation, "is_project_excluded", lambda path: False)
     monkeypatch.setattr(reconciliation, "resolve_key", lambda key: str(source))
     monkeypatch.setattr(reconciliation, "_source_available", lambda component: True)
+    monkeypatch.setattr(
+        reconciliation, "component_lock_update_required", lambda *args: False
+    )
     monkeypatch.setattr(
         reconciliation,
         "DEFAULT_RECIPE_REGISTRY",

--- a/tools/cc/tests/test_project_reconciliation_families.py
+++ b/tools/cc/tests/test_project_reconciliation_families.py
@@ -10,6 +10,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from cc.core.ecosystem import project_integration as integration
+from cc.core.ecosystem import project_reconciliation as reconciliation
+from cc.core.ecosystem import reconciliation_recipes as recipes
 from cc.core.ecosystem.project_locking import fingerprint_file_payload
 from cc.core.ecosystem.project_reconciliation import assess_project, build_project_plans
 from cc.core.ecosystem.reconciliation_recipes import (
@@ -19,10 +22,6 @@ from cc.core.ecosystem.reconciliation_recipes import (
 )
 from cc.core.ecosystem.reconciliation_transaction import execute_reconciliation
 from cc.core.ecosystem.reconciliation_types import ComponentRoute
-
-from cc.core.ecosystem import project_integration as integration
-from cc.core.ecosystem import project_reconciliation as reconciliation
-from cc.core.ecosystem import reconciliation_recipes as recipes
 
 
 def _git(project: Path, *arguments: str) -> str:
@@ -138,6 +137,7 @@ def _lock_entry(
         "component": component,
         "version": version,
         "release_tag": f"v{version}",
+        "ownership_mode": "full",
         "files": [
             {
                 "path": relative,
@@ -1005,6 +1005,39 @@ def test_custom_family_apply_verifies_and_repeats_without_work(
     assert public[0]["operations"] == []
     assert repeat_plans[0].operations == ()
     assert _git(project, "status", "--porcelain=v1")
+
+
+def test_customized_lock_source_drift_requires_owner_review(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    claude_source, codex_source = _framework_sources(tmp_path)
+    _configure_sources(monkeypatch, claude_source, codex_source)
+    project = _project(tmp_path, "customized-source-drift")
+    _install_current(project, claude_source, codex_source, ("claude",))
+    lock_path = project / "copilot.lock.json"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    lock["components"][0]["ownership_mode"] = "customized-preserve"
+    lock["components"][0]["files"] = [
+        item
+        for item in lock["components"][0]["files"]
+        if not item["path"].startswith(".claude/agents/")
+    ]
+    _write(lock_path, json.dumps(lock, indent=2) + "\n")
+    _commit(project)
+
+    version = json.loads((claude_source / "VERSION.json").read_text(encoding="utf-8"))
+    version["framework"] = "5.14.10"
+    _write(claude_source / "VERSION.json", json.dumps(version))
+    _write(claude_source / ".claude/commands/protocol.md", "updated protocol\n")
+
+    stale = assess_project(
+        project,
+        approved_root=tmp_path,
+        selected_components=("claude",),
+    )
+    assert stale["route"] == "owner-decision", stale
+    assert _component(stale, "claude")["state"] == "owner-decision"
+    assert _component(stale, "claude")["recipe_options"] == []
 
 
 def test_verified_read_only_knowledge_links_allow_local_dual_integration(

--- a/tools/cc/tests/test_reconciliation_recipes.py
+++ b/tools/cc/tests/test_reconciliation_recipes.py
@@ -577,6 +577,186 @@ def test_both_component_apply_and_repeat_proposes_zero_work(
     assert repeat_plans[0].operations == ()
 
 
+def test_verified_stale_lock_becomes_bounded_update_and_repeats(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = _project(tmp_path)
+    claude, codex = _framework_sources(tmp_path)
+    _configure_sources(monkeypatch, claude, codex)
+    monkeypatch.setattr(
+        project_module,
+        "inspect_project_integration",
+        integration_module.inspect_project_integration,
+    )
+    initial = assess_project(
+        project,
+        approved_root=tmp_path,
+        selected_components=("claude", "codex"),
+    )
+    _, initial_plans = build_project_plans(
+        [initial], {str(project): ("claude", "codex")}
+    )
+    first = execute_reconciliation(
+        [initial_plans[0].transaction_plan()],
+        run_id="run_" + "e" * 32,
+        root=tmp_path / "transaction-state",
+    )
+    assert first[0]["status"] == "applied"
+    _git(project, "add", "-A")
+    _git(project, "commit", "-qm", "initial integration")
+
+    version = json.loads((claude / "VERSION.json").read_text(encoding="utf-8"))
+    version["framework"] = "5.14.8"
+    version["components"]["commands"] = {
+        "projectCommands": ["protocol.md", "continue.md", "pause.md"]
+    }
+    _write(claude / "VERSION.json", json.dumps(version))
+    _write(claude / ".claude/commands/protocol.md", "updated protocol\n")
+    _write(claude / ".claude/commands/pause.md", "pause\n")
+
+    stale = assess_project(
+        project,
+        approved_root=tmp_path,
+        selected_components=("claude", "codex"),
+    )
+    states = {item["component"]: item["state"] for item in stale["components"]}
+    assert states == {"claude": "safe-update-available", "codex": "ready"}
+    assert stale["route"] == "safe-update-available"
+    claude_evidence = stale["components"][0]["evidence"]
+    assert any(
+        item["id"] == "claude-authoritative-source"
+        and item["state"] == "update-available"
+        for item in claude_evidence
+    )
+
+    public, update_plans = build_project_plans(
+        [stale], {str(project): ("claude", "codex")}
+    )
+    targets = {item["target"] for item in public[0]["operations"]}
+    assert ".claude/commands/pause.md" in targets
+    assert ".claude/commands/protocol.md" in targets
+    second = execute_reconciliation(
+        [update_plans[0].transaction_plan()],
+        run_id="run_" + "f" * 32,
+        root=tmp_path / "transaction-state",
+    )
+    assert second[0]["status"] == "applied"
+    lock = json.loads((project / "copilot.lock.json").read_text(encoding="utf-8"))
+    claude_entry = next(
+        entry for entry in lock["components"] if entry["component"] == "claude"
+    )
+    assert claude_entry["version"] == "5.14.8"
+    assert ".claude/commands/pause.md" in {
+        item["path"] for item in claude_entry["files"]
+    }
+
+    repeat = assess_project(
+        project,
+        approved_root=tmp_path,
+        selected_components=("claude", "codex"),
+    )
+    assert repeat["route"] == "ready"
+    repeated_public, repeated_internal = build_project_plans(
+        [repeat], {str(project): ("claude", "codex")}
+    )
+    assert repeated_public[0]["operations"] == []
+    assert repeated_internal[0].operations == ()
+
+
+def test_verified_stale_lock_is_held_when_project_has_active_work(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = _project(tmp_path)
+    claude, codex = _framework_sources(tmp_path)
+    _configure_sources(monkeypatch, claude, codex)
+    monkeypatch.setattr(
+        project_module,
+        "inspect_project_integration",
+        integration_module.inspect_project_integration,
+    )
+    initial = assess_project(
+        project,
+        approved_root=tmp_path,
+        selected_components=("claude", "codex"),
+    )
+    _, plans = build_project_plans([initial], {str(project): ("claude", "codex")})
+    receipt = execute_reconciliation(
+        [plans[0].transaction_plan()],
+        run_id="run_" + "1" * 32,
+        root=tmp_path / "transaction-state",
+    )
+    assert receipt[0]["status"] == "applied"
+    _git(project, "add", "-A")
+    _git(project, "commit", "-qm", "initial integration")
+
+    version = json.loads((claude / "VERSION.json").read_text(encoding="utf-8"))
+    version["framework"] = "5.14.8"
+    _write(claude / "VERSION.json", json.dumps(version))
+    _write(project / "owner-notes.md", "active work\n")
+
+    assessment = assess_project(
+        project,
+        approved_root=tmp_path,
+        selected_components=("claude", "codex"),
+    )
+    states = {item["component"]: item["state"] for item in assessment["components"]}
+    assert states == {"claude": "held", "codex": "ready"}
+    assert assessment["route"] == "held"
+    assert any(item["code"] == "dirty-working-tree" for item in assessment["blockers"])
+
+
+def test_new_framework_path_conflict_requires_owner_decision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = _project(tmp_path)
+    claude, codex = _framework_sources(tmp_path)
+    _configure_sources(monkeypatch, claude, codex)
+    monkeypatch.setattr(
+        project_module,
+        "inspect_project_integration",
+        integration_module.inspect_project_integration,
+    )
+    initial = assess_project(
+        project,
+        approved_root=tmp_path,
+        selected_components=("claude", "codex"),
+    )
+    _, plans = build_project_plans([initial], {str(project): ("claude", "codex")})
+    receipt = execute_reconciliation(
+        [plans[0].transaction_plan()],
+        run_id="run_" + "2" * 32,
+        root=tmp_path / "transaction-state",
+    )
+    assert receipt[0]["status"] == "applied"
+    _write(project / ".claude/commands/pause.md", "project-owned pause\n")
+    _git(project, "add", "-A")
+    _git(project, "commit", "-qm", "initial integration with local command")
+
+    version = json.loads((claude / "VERSION.json").read_text(encoding="utf-8"))
+    version["framework"] = "5.14.8"
+    version["components"]["commands"] = {
+        "projectCommands": ["protocol.md", "continue.md", "pause.md"]
+    }
+    _write(claude / "VERSION.json", json.dumps(version))
+    _write(claude / ".claude/commands/pause.md", "framework pause\n")
+
+    assessment = assess_project(
+        project,
+        approved_root=tmp_path,
+        selected_components=("claude", "codex"),
+    )
+    states = {item["component"]: item["state"] for item in assessment["components"]}
+    assert states == {"claude": "owner-decision", "codex": "ready"}
+    assert assessment["route"] == "owner-decision"
+    assert (project / ".claude/commands/pause.md").read_text(encoding="utf-8") == (
+        "project-owned pause\n"
+    )
+    assert any(
+        item["id"] == "claude-authoritative-source" and item["state"] == "conflict"
+        for item in assessment["components"][0]["evidence"]
+    )
+
+
 def test_sequential_claude_then_codex_apply_moves_shared_declaration_evidence_and_repeats(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- detect when a verified project lock differs from the current authoritative Claude or Codex source
- offer bounded updates for stable full-ownership installations while holding dirty work and stopping on collisions or retired paths
- preserve customized ownership boundaries and require owner review when those boundaries become stale
- add update, collision, dirty-tree, customized-boundary, and repeat-safety regression coverage

## Verification

- `PYTHONPATH=tools/cc/src pytest -q tools/cc/tests`
- focused reconciliation and assistant suites
- `ruff check` on changed Python files
- `bash scripts/test-version-consistency.sh`
- `COPILOT_PATH="$PWD" ./scripts/check-versions.sh`