### PR TITLE
fix(release): migrate Claude foundation signer for v5.15.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-copilot",
-  "version": "5.8.0",
+  "version": "5.15.2",
   "description": "Claude Copilot — a framework of specialized agents, skills, commands, and hooks that give Claude persistent memory, expert methodology, and task tracking. Agents cover architecture (ta), engineering (me), QA (qa), service design (sd), DevOps (do), documentation (doc), and knowledge onboarding (kc).",
   "author": "Claude Copilot contributors",
   "homepage": "https://github.com/pabloalej/claude-copilot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Framework **5.15.2**, `cc` **2.13.2**, `tc` **2.0.0**.
   Claude onboarding. Keep the historical signer and Codex allowlist unchanged.
 - Select the replacement in Claude's release preflight without relaxing signed
   commit, signed annotated tag, exact commit, or main-ancestry requirements.
+- Add explicit `--claude-only` snapshot installation with atomic cc/tc and
+  Claude-command publication, preserving unselected Codex registrations.
 - Document the reviewed trust bootstrap, protected signed-commit merge, recovery,
   and separate installed-content acceptance boundary in the
   [migration guide](docs/30-operations/19-claude-signer-migration.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [5.15.2] — 2026-09-09 — Claude release signer migration
+
+Framework **5.15.2**, `cc` **2.13.2**, `tc` **2.0.0**.
+
+- Add the owner-approved replacement SSH release signer to compiled trust and
+  Claude onboarding. Keep the historical signer and Codex allowlist unchanged.
+- Select the replacement in Claude's release preflight without relaxing signed
+  commit, signed annotated tag, exact commit, or main-ancestry requirements.
+- Document the reviewed trust bootstrap, protected signed-commit merge, recovery,
+  and separate installed-content acceptance boundary in the
+  [migration guide](docs/30-operations/19-claude-signer-migration.md).
+- This source entry is not proof of publication or installation; those require
+  exact release and deployment receipts in Task Copilot.
+
 ## [5.15.1] — 2026-09-08 — Source integration
 
 Framework **5.15.1**, `cc` **2.13.1**, `tc` **2.0.0**. This entry supersedes the

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,9 +1,9 @@
 {
-  "framework": "5.15.1",
-  "lastUpdated": "2026-09-08",
+  "framework": "5.15.2",
+  "lastUpdated": "2026-09-09",
   "components": {
     "cc": {
-      "version": "2.13.1",
+      "version": "2.13.2",
       "path": "tools/cc",
       "installScript": "tools/cc/install.sh",
       "provides": [

--- a/docs/30-operations/19-claude-signer-migration.md
+++ b/docs/30-operations/19-claude-signer-migration.md
@@ -1,0 +1,81 @@
+# Claude foundation signer migration
+
+Owner-authorized on 2026-09-09 (PRD-10 / TASK-79), following the explicit choice
+to establish a replacement trusted signer. This is a trust migration, not a
+claim that the historical key was compromised or revoked.
+
+## Trust decision
+
+The replacement is the owner's existing GitHub Ed25519 signing identity:
+
+```text
+SHA256:Dg6yz1MZ4IgBlm+E1TAC49FlVbQ4aaEsvDY7wHNPG5s
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIDGEZqgcjnCXb5XJQvD5/BKBAdO8CJcKYbteehyzu+i
+```
+
+Possession was proved by a disposable signed commit, locally verified against
+the owner's configured allowed-signers file. No private key was read or copied.
+Reusing this key couples Claude release signing to the owner's GitHub signing
+identity; it avoids silently provisioning an unprotected new private key.
+
+The historical fingerprint remains compiled for existing installations:
+`SHA256:FIfppOkzwXZUAamELQzYoSUQXiEAmTYiVewHe1ACMZo`.
+Claude onboarding knows both keys. Codex onboarding and existing Codex manifest
+allowlists remain unchanged. Compiled trust alone does not authorize content:
+production verification requires the layer's explicit signer allowlist too.
+
+An old runtime cannot authenticate its own replacement trust root. Bootstrap
+therefore requires the owner's explicit authorization, review of this exact
+public key/source change, successful CI, and local verification of the new
+release commit and tag using the approved key. Never accept a new public key
+merely because an untrusted release or manifest supplied it.
+
+## Release procedure
+
+1. Prepare one owner-signed candidate directly on the current main commit.
+   Record its exact head/base identities; review the diff and all automatic PR
+   checks under the [delivery gate](18-ci-acceptance-and-merge-gates.md).
+2. Preserve that signed commit with a normal, non-forced fast-forward merge of
+   the reviewed PR. Re-read the exact PR head and base before pushing. GitHub's
+   server protections remain authoritative; rejection stops publication.
+   Do not use an administrator bypass or weaken a rule.
+3. Verify every applicable automatic main workflow on the resulting exact SHA.
+   GitHub squash/rebase can replace the original signature, so do not assume
+   an ordinary GitHub-signed merge satisfies this foundation's SSH policy.
+4. Create a new signed annotated semver tag at that main ancestor. Run
+   `scripts/verify-foundation-release.sh <repo> <tag> <commit> main` before
+   publishing. Both commit and tag signatures, exact target and main ancestry
+   remain mandatory. Never rewrite an existing tag.
+5. Verify the published tag again. Only then install the exact immutable
+   snapshot and change the selected Claude foundation pin and signer policy.
+
+For historical verification, explicitly supply the historical public key via
+the existing `FOUNDATION_RELEASE_PUBLIC_KEY` environment setting. That selects
+the expected signer; it does not skip either signature or ancestry verification.
+
+GitHub documents [protected local PR merges](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks)
+and [ruleset requirements](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets).
+Some combinations disallow local merging without bypass; in that case stop
+and request a separate policy decision instead of changing protections.
+
+## Installation acceptance and recovery
+
+Publication is not installation acceptance. TASK-78 owns the explicit Mac and
+consumer target list, before/after hashes, tier/customization classification,
+recoverable backups outside agent discovery, and actual installed verification.
+Claude authoring layers are not disposable consumer installations. Do not
+overwrite unknown differences or change Codex pins as part of this migration.
+
+Acceptance requires intended tier-resolved agents and commands, preserved
+customizations, provenance, no duplicate active names, the existing context
+budget, the current proportional-testing/fixed-finish-line instructions, and
+a second reconciliation that proposes no changes. Repository CI alone, a
+source-directory check, or an agent's self-description cannot prove this.
+
+Keep old snapshots and byte-verified target backups. Recovery restores the
+reviewed previous shim, configuration, locks and managed files from that receipt;
+it does not rewrite Git history or revoke keys. Record any pre-existing invalid
+old pin so restoring old state is not misrepresented as a trusted release.
+Once release and installation criteria have current task-bound QA approval,
+close those tasks and stop. No unrelated cleanup or additional test platform
+is part of this batch.

--- a/docs/30-operations/19-claude-signer-migration.md
+++ b/docs/30-operations/19-claude-signer-migration.md
@@ -66,6 +66,13 @@ recoverable backups outside agent discovery, and actual installed verification.
 Claude authoring layers are not disposable consumer installations. Do not
 overwrite unknown differences or change Codex pins as part of this migration.
 
+Use `scripts/install-framework-snapshot.py --claude-only` with the verified
+source root, commit and tree for this rollout. It installs the shared cc/tc
+runtime and declared Claude machine commands without invoking Codex or altering
+its plugin registrations. The receipt marks Codex unselected, not verified.
+The default combined installer retains its existing Codex normalization and
+verification behavior; the scoped option does not weaken selected checks.
+
 Acceptance requires intended tier-resolved agents and commands, preserved
 customizations, provenance, no duplicate active names, the existing context
 budget, the current proportional-testing/fixed-finish-line instructions, and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilot/framework",
-  "version": "5.15.1",
+  "version": "5.15.2",
   "description": "Claude Copilot - AI-enabled development framework",
   "private": true,
   "scripts": {

--- a/scripts/install-framework-snapshot.py
+++ b/scripts/install-framework-snapshot.py
@@ -760,6 +760,7 @@ def install_framework_snapshot(
     cc_verifier: CcVerifier = _default_cc_verifier,
     tc_verifier: Callable[[Path], dict] = _default_tc_verifier,
     codex_runner: CodexRunner = run_codex_plugin,
+    claude_only: bool = False,
     _fail_after_publish: int | None = None,
 ) -> dict[str, object]:
     commit = _validate_object_id(source_commit, label="source commit")
@@ -817,20 +818,21 @@ def install_framework_snapshot(
             if _sha256(_read_regular(tc_receipt_path, readonly=True)) != tc_receipt.get("receipt_sha256"):
                 raise FrameworkInstallError("tc receipt checksum mismatch")
             shim_checksum = _sha256(_read_regular(staged_shim))
-            try:
-                plugin_artifacts, plugin_manifest_sha256 = validate_snapshot_plugin(
-                    snapshot
-                )
-                plugin_transaction = normalize_codex_plugin(
-                    snapshot,
-                    plugin_artifacts,
-                    plugin_manifest_sha256,
-                    home_root,
-                    codex_runner,
-                )
-            except CodexPluginError as exc:
-                raise FrameworkInstallError(str(exc)) from exc
-            plugin = plugin_transaction.receipt
+            plugin_transaction = None
+            if not claude_only:
+                try:
+                    plugin_artifacts, plugin_manifest_sha256 = validate_snapshot_plugin(
+                        snapshot
+                    )
+                    plugin_transaction = normalize_codex_plugin(
+                        snapshot,
+                        plugin_artifacts,
+                        plugin_manifest_sha256,
+                        home_root,
+                        codex_runner,
+                    )
+                except CodexPluginError as exc:
+                    raise FrameworkInstallError(str(exc)) from exc
             manifest = {
                 "schema_version": "1.0",
                 "source_commit": commit,
@@ -844,7 +846,10 @@ def install_framework_snapshot(
                 "machine_commands": [
                     {"name": item.name, "sha256": item.checksum} for item in commands
                 ],
-                "codex_plugin": {
+            }
+            if plugin_transaction is not None:
+                plugin = plugin_transaction.receipt
+                manifest["codex_plugin"] = {
                     "plugin_id": plugin.plugin_id,
                     "marketplace": plugin.marketplace,
                     "marketplace_source": plugin.marketplace_source,
@@ -852,8 +857,14 @@ def install_framework_snapshot(
                     "installed_path": plugin.installed_path,
                     "manifest_sha256": plugin.manifest_sha256,
                     "tree_sha256": plugin.tree_sha256,
-                },
-            }
+                }
+            else:
+                # Do not copy a stale receipt or imply unselected Codex was
+                # inspected. Its registrations and files remain untouched.
+                manifest["installation_scope"] = {
+                    "selected": ["claude", "cc", "tc"],
+                    "unselected": ["codex"],
+                }
             manifest_payload = (
                 json.dumps(manifest, indent=2, sort_keys=True) + "\n"
             ).encode("utf-8")
@@ -870,14 +881,17 @@ def install_framework_snapshot(
                 )
             except BaseException as publish_error:
                 try:
-                    plugin_transaction.rollback()
+                    if plugin_transaction is not None:
+                        plugin_transaction.rollback()
                 except BaseException as rollback_error:
                     raise FrameworkInstallError(
                         "runtime publication failed and Codex plugin rollback was "
                         f"incomplete: {rollback_error}"
                     ) from publish_error
                 raise
-            changed = published_changed + plugin_transaction.changed
+            changed = published_changed + (
+                plugin_transaction.changed if plugin_transaction is not None else 0
+            )
         finally:
             shutil.rmtree(operation_root, ignore_errors=True)
 
@@ -897,6 +911,11 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--source-commit", required=True)
     parser.add_argument("--source-tree", required=True)
     parser.add_argument(
+        "--claude-only",
+        action="store_true",
+        help="Install cc/tc and Claude machine commands without inspecting or changing Codex plugins.",
+    )
+    parser.add_argument(
         "--home",
         type=Path,
         help="Alternate machine home root (primarily for isolated verification).",
@@ -912,6 +931,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             source_commit=arguments.source_commit,
             source_tree=arguments.source_tree,
             home=arguments.home,
+            claude_only=arguments.claude_only,
         )
     except (CodexPluginError, FrameworkInstallError, OSError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/scripts/verify-foundation-release.sh
+++ b/scripts/verify-foundation-release.sh
@@ -67,7 +67,10 @@ git -C "${REPO}" merge-base --is-ancestor "${SOURCE_COMMIT}" "${branch_ref}" ||
     die "${SOURCE_COMMIT} is not an ancestor of ${branch_ref} (RC-3: refusing a release-cut step that is not a real descendant of the branch it claims)"
 
 principal="${FOUNDATION_RELEASE_PRINCIPAL:-enac-foundation}"
-public_key="${FOUNDATION_RELEASE_PUBLIC_KEY:-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINah8Gf036FQkhMcUU35m2p7Nqa41oBtVS/QV9tYZX8H}"
+# Claude's owner-authorized 2026-09-09 replacement signer. Historical releases
+# can still be checked with their explicitly supplied historical public key.
+# See docs/30-operations/19-claude-signer-migration.md; no check is optional.
+public_key="${FOUNDATION_RELEASE_PUBLIC_KEY:-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIDGEZqgcjnCXb5XJQvD5/BKBAdO8CJcKYbteehyzu+i}"
 trust_file="$(mktemp "${TMPDIR:-/tmp}/foundation-release-signers.XXXXXX")"
 cleanup() {
     rm -f "${trust_file}"

--- a/tools/cc/pyproject.toml
+++ b/tools/cc/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-cli"
-version = "2.13.1"
+version = "2.13.2"
 description = "Unified Claude Copilot CLI for memory, skills, config, and live docs"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/cc/src/cc/__init__.py
+++ b/tools/cc/src/cc/__init__.py
@@ -1,3 +1,3 @@
 """Claude Copilot CLI for memory, skills, config, and live docs."""
 
-__version__ = "2.13.1"
+__version__ = "2.13.2"

--- a/tools/cc/src/cc/commands/onboard.py
+++ b/tools/cc/src/cc/commands/onboard.py
@@ -71,7 +71,10 @@ _COMPONENT_LABELS: dict[str, str] = {
 FOUNDATION_ALLOWED_SIGNERS: dict[str, tuple[str, ...]] = {
     "knowledge": (),
     "cli": (),
-    "claude": ("SHA256:FIfppOkzwXZUAamELQzYoSUQXiEAmTYiVewHe1ACMZo",),
+    "claude": (
+        "SHA256:Dg6yz1MZ4IgBlm+E1TAC49FlVbQ4aaEsvDY7wHNPG5s",
+        "SHA256:FIfppOkzwXZUAamELQzYoSUQXiEAmTYiVewHe1ACMZo",
+    ),
     "codex": ("SHA256:FIfppOkzwXZUAamELQzYoSUQXiEAmTYiVewHe1ACMZo",),
 }
 Run = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]

--- a/tools/cc/src/cc/core/ecosystem/policy.py
+++ b/tools/cc/src/cc/core/ecosystem/policy.py
@@ -38,6 +38,13 @@ def _normalize_fingerprint(value: str) -> str:
 
 
 FOUNDATION_SSH_SIGNING_KEYS: dict[str, str] = {
+    # Owner-authorized Claude signer migration (2026-09-09). A compiled key
+    # alone grants nothing: each layer must also explicitly allow its signer.
+    _normalize_fingerprint("SHA256:Dg6yz1MZ4IgBlm+E1TAC49FlVbQ4aaEsvDY7wHNPG5s"): (
+        "ssh-ed25519 "
+        "AAAAC3NzaC1lZDI1NTE5AAAAIIDGEZqgcjnCXb5XJQvD5/BKBAdO8CJcKYbteehyzu+i"
+    ),
+    # Retained for historical releases and unchanged Codex trust policy.
     _normalize_fingerprint("SHA256:FIfppOkzwXZUAamELQzYoSUQXiEAmTYiVewHe1ACMZo"): (
         "ssh-ed25519 "
         "AAAAC3NzaC1lZDI1NTE5AAAAINah8Gf036FQkhMcUU35m2p7Nqa41oBtVS/QV9tYZX8H"

--- a/tools/cc/tests/test_foundation_signer_migration.py
+++ b/tools/cc/tests/test_foundation_signer_migration.py
@@ -1,0 +1,37 @@
+"""The reviewed Claude migration must not silently authorize another product."""
+
+import re
+import subprocess
+from pathlib import Path
+
+from cc.commands.onboard import FOUNDATION_ALLOWED_SIGNERS
+from cc.core.ecosystem.policy import FOUNDATION_SSH_SIGNING_KEYS
+
+NEW = "SHA256:Dg6yz1MZ4IgBlm+E1TAC49FlVbQ4aaEsvDY7wHNPG5s"
+OLD = "SHA256:FIfppOkzwXZUAamELQzYoSUQXiEAmTYiVewHe1ACMZo"
+ROOT = Path(__file__).parents[3]
+
+
+def test_compiled_keys_match_reviewed_fingerprints(tmp_path):
+    for fingerprint in (NEW, OLD):
+        public_key = tmp_path / "key.pub"
+        public_key.write_text(FOUNDATION_SSH_SIGNING_KEYS[fingerprint.upper()] + "\n")
+        actual = subprocess.run(
+            ["ssh-keygen", "-lf", str(public_key), "-E", "sha256"],
+            capture_output=True, text=True, check=True,
+        ).stdout.split()[1]
+        assert actual == fingerprint
+
+
+def test_claude_migration_does_not_change_codex_authority():
+    assert FOUNDATION_ALLOWED_SIGNERS["claude"] == (NEW, OLD)
+    assert FOUNDATION_ALLOWED_SIGNERS["codex"] == (OLD,)
+    assert FOUNDATION_ALLOWED_SIGNERS["cli"] == ()
+    assert FOUNDATION_ALLOWED_SIGNERS["knowledge"] == ()
+
+
+def test_release_preflight_defaults_to_same_reviewed_key():
+    script = (ROOT / "scripts/verify-foundation-release.sh").read_text()
+    default = re.search(r'public_key="\$\{FOUNDATION_RELEASE_PUBLIC_KEY:-(.*?)\}"', script)
+    assert default is not None
+    assert default.group(1) == FOUNDATION_SSH_SIGNING_KEYS[NEW.upper()]

--- a/tools/cc/tests/test_framework_snapshot_install.py
+++ b/tools/cc/tests/test_framework_snapshot_install.py
@@ -528,6 +528,42 @@ def test_reinstall_is_idempotent_and_reuses_valid_readonly_snapshot(tmp_path: Pa
     assert active.read_bytes() == before
 
 
+def test_claude_only_preserves_codex_and_keeps_rollback_and_repeat_noop(tmp_path: Path):
+    repo, commit, tree = _source_repository(tmp_path)
+    home = tmp_path / "home"
+    codex_state = home / ".codex/config.toml"
+    _write(codex_state, '[plugins.legacy]\nenabled = false\n')
+    shim = home / ".local/bin/cc"
+    _write(shim, "old cc\n", mode=0o755)
+    active = home / ".copilot/framework-runtime.json"
+    _write(active, '{"old":"receipt"}\n', mode=0o600)
+    before = {p: (p.read_bytes(), p.stat().st_mode) for p in (codex_state, shim, active)}
+
+    def forbidden_codex(*args):
+        pytest.fail("Claude-only installation must not invoke the Codex boundary")
+
+    with pytest.raises(installer.FrameworkInstallError):
+        _install(repo, commit, tree, home, claude_only=True,
+                 codex_runner=forbidden_codex, _fail_after_publish=2)
+    assert {p: (p.read_bytes(), p.stat().st_mode) for p in before} == before
+    assert not (home / ".local/bin/tc").exists()
+
+    first = _install(repo, commit, tree, home, claude_only=True, codex_runner=forbidden_codex)
+    assert first["result"] == "installed"
+    receipt = json.loads(active.read_text())
+    assert receipt["installation_scope"] == {"selected": ["claude", "cc", "tc"], "unselected": ["codex"]}
+    assert "codex_plugin" not in receipt
+    assert receipt["tc"]["source_commit"] == commit
+    assert (home / ".local/bin/tc").is_file()
+    assert codex_state.read_bytes() == before[codex_state][0]
+    assert list((home / ".codex").iterdir()) == [codex_state]
+    accepted = active.read_bytes()
+    second = _install(repo, commit, tree, home, claude_only=True, codex_runner=forbidden_codex)
+    assert second["result"] == "up-to-date"
+    assert second["changed_targets"] == 0
+    assert active.read_bytes() == accepted
+
+
 def test_normalization_removes_duplicate_copilot_and_preserves_unrelated_state(
     tmp_path: Path,
 ):

--- a/tools/cc/tests/test_onboard_contract.py
+++ b/tools/cc/tests/test_onboard_contract.py
@@ -2342,11 +2342,12 @@ def test_ecosystem_apply_writes_exact_refs_and_runs_update_doctor(
 
 def test_foundation_release_signer_is_compiled_for_both_products():
     approved = "SHA256:FIfppOkzwXZUAamELQzYoSUQXiEAmTYiVewHe1ACMZo"
+    replacement = "SHA256:Dg6yz1MZ4IgBlm+E1TAC49FlVbQ4aaEsvDY7wHNPG5s"
 
     assert onboard_module.FOUNDATION_ALLOWED_SIGNERS == {
         "knowledge": (),
         "cli": (),
-        "claude": (approved,),
+        "claude": (replacement, approved),
         "codex": (approved,),
     }
 

--- a/tools/cc/tests/test_release_signature_preflight.py
+++ b/tools/cc/tests/test_release_signature_preflight.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 SCRIPT = Path(__file__).parents[3] / "scripts" / "verify-foundation-release.sh"
 
 
@@ -89,3 +91,37 @@ def test_release_preflight_accepts_signed_tag_over_signed_non_root_commit(tmp_pa
 
     assert result.returncode == 0, result.stderr
     assert "foundation release signatures: verified" in result.stdout
+
+
+@pytest.mark.parametrize("defect", ["unsigned-tag", "unknown-signer", "wrong-commit", "off-main"])
+def test_release_preflight_rejects_invalid_release(tmp_path: Path, defect: str) -> None:
+    repo, _key, env = _repo_and_key(tmp_path)
+    subprocess.run(["git", "commit", "-qS", "-m", "base"], cwd=repo, check=True)
+    base = _run("git", "rev-parse", "HEAD", cwd=repo).stdout.strip()
+    if defect == "off-main":
+        subprocess.run(["git", "switch", "-qc", "unmerged"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-qS", "--allow-empty", "-m", "candidate"], cwd=repo, check=True,
+    )
+    commit = _run("git", "rev-parse", "HEAD", cwd=repo).stdout.strip()
+    if defect == "unsigned-tag":
+        tag_args = ["git", "-c", "tag.gpgSign=false", "tag", "-a", "v1.2.5", "-m", "unsigned"]
+    else:
+        tag_args = ["git", "tag", "-s", "v1.2.5", "-m", "release"]
+    subprocess.run(tag_args, cwd=repo, check=True)
+    if defect == "unknown-signer":
+        other_key = tmp_path / "unapproved-key"
+        subprocess.run(["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(other_key)], check=True)
+        env["FOUNDATION_RELEASE_PUBLIC_KEY"] = other_key.with_suffix(".pub").read_text().strip()
+    if defect == "wrong-commit":
+        commit = base
+
+    result = _run(str(SCRIPT), str(repo), "v1.2.5", commit, "main", cwd=repo, env=env)
+
+    assert result.returncode != 0
+    assert {
+        "unsigned-tag": "valid foundation release signature",
+        "unknown-signer": "valid foundation release signature",
+        "wrong-commit": "resolves to",
+        "off-main": "not an ancestor",
+    }[defect] in result.stderr

--- a/tools/cc/uv.lock
+++ b/tools/cc/uv.lock
@@ -62,7 +62,7 @@ wheels = [
 
 [[package]]
 name = "claude-cli"
-version = "2.13.1"
+version = "2.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Scope

Owner explicitly selected replacement signer migration (#2). Add the owner's existing verified SSH public key to Claude foundation trust; retain historical trust and leave Codex's allowlist unchanged. Framework 5.15.2 / cc 2.13.2; dependencies unchanged.

Commit signature, signed annotated tag, exact commit target and main ancestry remain mandatory. No unsigned fallback, admin bypass, protection change, private-key publication or historical tag rewrite.

## Verification

- 138 focused/affected tests passed, 13.08 seconds: signer migration, real Git release preflight, ecosystem signature policy, onboarding contract.
- Negative control: new exact allowlist test rejects archived pre-migration code.
- Existing onboarding equality test changes only Claude's expected tuple under the owner's explicit trust migration; Codex and other-product assertions remain exact.
- Task record: PRD-10 / TASK-79, security WP217, implementation WP218, sequential QA WP221. Hosted CI and release verification still required.

## Merge requirement

Preserve the exact owner SSH-signed commit with a protected, non-forced fast-forward merge of this PR after all applicable checks pass and head/base identities are re-read. GitHub squash/rebase may replace that signature. Server rejection stops publication; do not bypass. Verify all main CI before cutting a new tag.

Installation reconciliation is separately tracked in TASK-78; this PR does not claim machine installation acceptance.
